### PR TITLE
Docker-compose for production envs and separate one for e2e tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,6 +79,6 @@ jobs:
           ./gen_vars.sh test
       - name: Perform tests
         run: |
-          docker-compose up -d
-          docker-compose logs -f -t mwdb-tests
+          docker-compose -f docker-compose-e2e.yml up -d
+          docker-compose -f docker-compose-e2e.yml logs -f -t mwdb-tests
           docker wait malwarecage_mwdb-tests_1

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,3 +1,5 @@
+# Docker Compose file for Malwarecage development environment
+
 version: "3.3"
 services:
   mwdb:

--- a/docker-compose-e2e.yml
+++ b/docker-compose-e2e.yml
@@ -1,4 +1,4 @@
-# Docker Compose file for Malwarecage production service
+# Docker Compose file for Malwarecage end-to-end test suite
 
 version: "3.3"
 services:
@@ -14,8 +14,6 @@ services:
     env_file:
       # NOTE: use gen_vars.sh in order to generate this file
       - mwdb-vars.env
-    volumes:
-      - malwarecage-uploads:/app/uploads
   malwarefront:
     depends_on:
       - mwdb
@@ -32,11 +30,10 @@ services:
     env_file:
       # NOTE: use gen_vars.sh in order to generate this file
       - postgres-vars.env
-    volumes:
-      - malwarecage-postgres:/var/lib/postgresql/data
+  mwdb-tests:
+    build: tests
+    image: certpl/malwarecage-tests
+    env_file:
+      - mwdb-vars.env
   redis:
     image: redis:alpine
-
-volumes:
-  malwarecage-postgres:
-  malwarecage-uploads:


### PR DESCRIPTION
**Current behavior**

Current `docker-compose.yml` is applicable only for e2e tests. It should provide good first installation experience instead

**New behavior**
- `docker-compose.yml` was moved to `docker-compose-e2e.yml`
- Original `docker-compose.yml` doesn't include `mwdb-tests` service and sets Docker volumes for PostgreSQL database and uploads directory.