### PR TITLE
Set up CI to work correctly with forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,8 +65,8 @@ jobs:
         uses: actions/download-artifact@v2
       - name: Import images
         run: |
-          docker load --input ./malwarecage-image
-          docker load --input ./malwarecage-web-image
+          docker load --input ./malwarecage-image/malwarecage-image
+          docker load --input ./malwarecage-web-image/malwarecage-web-image
           docker tag certpl/malwarecage:$GITHUB_SHA certpl/malwarecage:latest
           docker tag certpl/malwarecage-web:$GITHUB_SHA certpl/malwarecage-web:latest
       - name: Build test image

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
     - master
-    - ci/*
   pull_request:
     branches:
     - master
@@ -16,13 +15,15 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
-      - name: Build Malwarecage image
+      - name: Build and push Malwarecage image
         uses: docker/build-push-action@v1.1.0
         with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
           dockerfile: ./deploy/docker/Dockerfile
           repository: certpl/malwarecage
           tags: ${{ github.sha }}
-          push: false
+          push: ${{ github.event == 'push' }}
       - name: Store Malwarecage image 
         run: docker save -o ./malwarecage-image certpl/malwarecage:${{ github.sha }}
       - name: Upload Malwarecage image
@@ -41,19 +42,46 @@ jobs:
       - name: Build and push Malwarefront image
         uses: docker/build-push-action@v1.1.0
         with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
           dockerfile: ./deploy/docker/Dockerfile-web
           repository: certpl/malwarecage-web
           tags: ${{ github.sha }}
-          push: false
-      - name: Store Malwarecage image 
+          push: ${{ github.event == 'push' }} 
+      - name: Store Malwarefront image 
         run: docker save -o ./malwarecage-web-image certpl/malwarecage-web:${{ github.sha }}
-      - name: Upload Malwarecage image
+      - name: Upload Malwarefront image
         uses: actions/upload-artifact@v2 
         with:
           name: malwarecage-web-image
           path: malwarecage-web-image
+  build_e2e:
+    name: Build e2e test image
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_BUILDKIT: 1
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+      - name: Build and push test image
+        uses: docker/build-push-action@v1.1.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          dockerfile: ./tests/Dockerfile
+          repository: certpl/malwarecage-tests
+          path: tests
+          tags: ${{ github.sha }}
+          push: ${{ github.event == 'push' }} 
+      - name: Store test image 
+        run: docker save -o ./malwarecage-tests-image certpl/malwarecage-tests:${{ github.sha }}
+      - name: Upload test image
+        uses: actions/upload-artifact@v2 
+        with:
+          name: malwarecage-tests-image
+          path: malwarecage-tests-image
   test_e2e:
-    needs: [build_core, build_frontend] 
+    needs: [build_core, build_frontend, build_e2e] 
     name: Perform e2e tests
     runs-on: ubuntu-latest
     env:
@@ -67,16 +95,10 @@ jobs:
         run: |
           docker load --input ./malwarecage-image/malwarecage-image
           docker load --input ./malwarecage-web-image/malwarecage-web-image
+          docker load --input ./malwarecage-tests-image/malwarecage-tests-image
           docker tag certpl/malwarecage:$GITHUB_SHA certpl/malwarecage:latest
           docker tag certpl/malwarecage-web:$GITHUB_SHA certpl/malwarecage-web:latest
-      - name: Build test image
-        uses: docker/build-push-action@v1.1.0
-        with:
-          dockerfile: ./tests/Dockerfile
-          repository: certpl/malwarecage-tests
-          path: tests
-          tags: latest
-          push: false
+          docker tag certpl/malwarecage-tests:$GITHUB_SHA certpl/malwarecage-tests:latest
       - name: Setup configuration      
         run: |
           chmod +x gen_vars.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
     - master
+    - ci/*
   pull_request:
     branches:
     - master
@@ -15,14 +16,20 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
-      - name: Build and push Malwarecage image
+      - name: Build Malwarecage image
         uses: docker/build-push-action@v1.1.0
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
           dockerfile: ./deploy/docker/Dockerfile
           repository: certpl/malwarecage
           tags: ${{ github.sha }}
+          push: false
+      - name: Store Malwarecage image 
+        run: docker save -o ./malwarecage-image certpl/malwarecage:${{ github.sha }}
+      - name: Upload Malwarecage image
+        uses: actions/upload-artifact@v2 
+        with:
+          name: malwarecage-image
+          path: malwarecage-image
   build_frontend:
     name: Build Malwarecage frontend image
     runs-on: ubuntu-latest
@@ -34,30 +41,19 @@ jobs:
       - name: Build and push Malwarefront image
         uses: docker/build-push-action@v1.1.0
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
           dockerfile: ./deploy/docker/Dockerfile-web
           repository: certpl/malwarecage-web
           tags: ${{ github.sha }}
-  build_e2e:
-    name: Build e2e test image
-    runs-on: ubuntu-latest
-    env:
-      DOCKER_BUILDKIT: 1
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v2
-      - name: Build test image
-        uses: docker/build-push-action@v1.1.0
+          push: false
+      - name: Store Malwarecage image 
+        run: docker save -o ./malwarecage-web-image certpl/malwarecage-web:${{ github.sha }}
+      - name: Upload Malwarecage image
+        uses: actions/upload-artifact@v2 
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-          dockerfile: ./tests/Dockerfile
-          repository: certpl/malwarecage-tests
-          path: tests
-          tags: ${{ github.sha }}
+          name: malwarecage-web-image
+          path: malwarecage-web-image
   test_e2e:
-    needs: [build_core, build_e2e, build_frontend] 
+    needs: [build_core, build_frontend] 
     name: Perform e2e tests
     runs-on: ubuntu-latest
     env:
@@ -65,14 +61,22 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
-      - name: Pull images
+      - name: Download all artifacts
+        uses: actions/download-artifact@v2
+      - name: Import images
         run: |
-          docker pull certpl/malwarecage:$GITHUB_SHA > /dev/null
-          docker pull certpl/malwarecage-web:$GITHUB_SHA > /dev/null
-          docker pull certpl/malwarecage-tests:$GITHUB_SHA > /dev/null
+          docker load --input ./malwarecage-image
+          docker load --input ./malwarecage-web-image
           docker tag certpl/malwarecage:$GITHUB_SHA certpl/malwarecage:latest
           docker tag certpl/malwarecage-web:$GITHUB_SHA certpl/malwarecage-web:latest
-          docker tag certpl/malwarecage-tests:$GITHUB_SHA certpl/malwarecage-tests:latest
+      - name: Build test image
+        uses: docker/build-push-action@v1.1.0
+        with:
+          dockerfile: ./tests/Dockerfile
+          repository: certpl/malwarecage-tests
+          path: tests
+          tags: latest
+          push: false
       - name: Setup configuration      
         run: |
           chmod +x gen_vars.sh


### PR DESCRIPTION
**Current behavior**

Secrets are not passed to the workflows, so CI doesn't work for pull requests from external contributors

**Fixed behavior**
- Docker images are now passed between jobs via artifacts
- When workflow is triggered by push into master (merged PR), images are pushed into Docker Hub (secrets will be available at this point).