### PR TITLE
Remove argumentless form of ShareResource (/share)

### DIFF
--- a/core/service.py
+++ b/core/service.py
@@ -134,7 +134,7 @@ def setup_restful_service(app):
     spec.path(resource=CommentResource, api=api)
     api.add_resource(TagResource, '/<any(file, config, blob, object):type>/<hash64:identifier>/tag')
     spec.path(resource=TagResource, api=api)
-    api.add_resource(ShareResource, '/share', '/<any(file, config, blob, object):type>/<hash64:identifier>/share')
+    api.add_resource(ShareResource, '/<any(file, config, blob, object):type>/<hash64:identifier>/share')
     spec.path(resource=ShareResource, api=api)
     api.add_resource(MetakeyResource, '/<any(file, config, blob, object):type>/<hash64:identifier>/meta')
     spec.path(resource=MetakeyResource, api=api)

--- a/resources/share.py
+++ b/resources/share.py
@@ -16,7 +16,7 @@ from . import authenticated_access, logger, requires_authorization
 
 class ShareResource(Resource):
     @requires_authorization
-    def get(self, type=None, identifier=None):
+    def get(self, type, identifier):
         """
         ---
         description: Get sharing info for specified object

--- a/resources/share.py
+++ b/resources/share.py
@@ -51,9 +51,6 @@ class ShareResource(Resource):
             groups = list(map(itemgetter(0), db.session.query(Group.name).filter(
                 g.auth_user.is_member(Group.id)
             ).all()))
-        if identifier is None:
-            schema = ShareShowSchema()
-            return schema.dump({"groups": groups})
 
         db_object = authenticated_access(Object, identifier)
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
ShareResource accepts the variant without arguments (`/share` instead of `/<type>/<identifier>/share`) which returns only list of our own `groups` (groups that we can share object with).

This variant incorrectly reuses the ShareResource:
- accepts `PUT /share` which doesn't have any sense
- can't be covered by OAS3 documentation and rendered correctly by Swagger (Swagger renders only the `/share` variant)

Both mwdblib and web uses only `/<type>/<identifier>/share` variant. If we want to share object with group, we still need the access to this object (precondition that must be fulfilled).

Currently `/<type>/<identifier>/share` returns both list of groups and list of shares for specified object.

**What is the new behaviour?**
Malwarecage doesn't accept `/share` endpoint

It's breaking change but endpoint doesn't seem to be used by clients.

**Test plan**
- Check if `Share with group` still works after this change
