### PR TITLE
Use `@requires_capabilities` in ObjectChildResource 

### DIFF
--- a/resources/object.py
+++ b/resources/object.py
@@ -10,7 +10,7 @@ from core.capabilities import Capabilities
 from core.schema import ObjectShowBase, MetakeyShowSchema, MultiObjectSchema
 from core.search import SQLQueryBuilder, SQLQueryBuilderBaseException
 
-from . import logger, authenticated_access, requires_authorization
+from . import logger, authenticated_access, requires_authorization, requires_capabilities
 
 
 class ObjectListResource(Resource):
@@ -234,6 +234,7 @@ class ObjectResource(Resource):
 
 class ObjectChildResource(Resource):
     @requires_authorization
+    @requires_capabilities(Capabilities.adding_parents)
     def put(self, type, parent, child):
         """
         ---
@@ -265,8 +266,6 @@ class ObjectChildResource(Resource):
             200:
                 description: When relation was successfully added
         """
-        if not g.auth_user.has_rights(Capabilities.adding_parents):
-            raise Forbidden("You are not permitted to perform this action")
         parent_object = authenticated_access(Object, parent)
         child_object = authenticated_access(Object, child)
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [x] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
- ObjectChildResource requires `adding_parents` capability
- Requirement handled via `has_rights` method instead of `@requires_capabilities` decorator.

**What is the new behaviour?**
- ObjectChildResource uses `@requires_capabilities` decorator just like the other methods.

**Test plan**

- Possible permission break already covered by automated tests
