### PR TITLE
Rollbacked /share endpoint removal required by Upload view

### DIFF
--- a/core/service.py
+++ b/core/service.py
@@ -22,7 +22,7 @@ from resources.object import ObjectResource, ObjectListResource, ObjectChildReso
 from resources.relations import RelationsResource
 from resources.server import PingResource, ServerInfoResource
 from resources.search import SearchResource
-from resources.share import ShareResource
+from resources.share import ShareGroupListResource, ShareResource
 from resources.tag import TagResource, TagListResource
 from resources.user import UserResource, UserListResource, UserPendingResource
 
@@ -139,6 +139,8 @@ def setup_restful_service(app):
     spec.path(resource=TagResource, api=api)
     api.add_resource(ShareResource, '/<any(file, config, blob, object):type>/<hash64:identifier>/share')
     spec.path(resource=ShareResource, api=api)
+    api.add_resource(ShareGroupListResource, '/share')
+    spec.path(resource=ShareGroupListResource, api=api)
     api.add_resource(MetakeyResource, '/<any(file, config, blob, object):type>/<hash64:identifier>/meta')
     spec.path(resource=MetakeyResource, api=api)
     api.add_resource(ObjectChildResource,

--- a/tests/test_sharing.py
+++ b/tests/test_sharing.py
@@ -90,3 +90,39 @@ def test_share_and_leave():
 
     session.remove_member(Workgroup.identity, Joe.identity)
     File(should_access=[Alice, Bob]).test()
+
+
+def test_list_groups_for_share():
+    testCase = RelationTestCase()
+
+    Alice = testCase.new_user("Alice")
+    Bob = testCase.new_user("Bob")
+    Joe = testCase.new_user("Joe")
+
+    Workgroup = testCase.new_group("Workgroup")
+    Homegroup = testCase.new_group("Homegroup", ["sharing_objects"])
+
+    Workgroup.add_member(Alice)
+    Workgroup.add_member(Bob)
+    Homegroup.add_member(Joe)
+
+    assert sorted(Alice.session().get_sharing_groups()) == sorted([
+        Alice.identity,
+        Workgroup.identity,
+        "public"
+    ])
+
+    assert sorted(Bob.session().get_sharing_groups()) == sorted([
+        Bob.identity,
+        Workgroup.identity,
+        "public"
+    ])
+
+    assert set(Joe.session().get_sharing_groups()).issuperset([
+        Alice.identity,
+        Bob.identity,
+        Joe.identity,
+        Homegroup.identity,
+        Workgroup.identity,
+        "public"
+    ])

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -99,6 +99,11 @@ class MwdbTest(object):
         res.raise_for_status()
         return res.json()
 
+    def get_sharing_groups(self):
+        res = self.session.get(self.mwdb_url + '/share')
+        res.raise_for_status()
+        return res.json()["groups"]
+
     def share_with(self, identifier, name):
         res = self.session.put(self.mwdb_url + '/object/' + identifier + '/share', json={
             "group": name


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [x] I've added automated tests for my change (if applicable, optional)
- [x] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**

`/share` endpoint was removed in #45 due to various issues described in PR.

> It's breaking change but endpoint doesn't seem to be used by clients.

Actually it is used by `Upload` view to determine the set of groups that user can share uploaded object with.

**What is the new behaviour?**

- Reimplemented `/share` endpoint as separate resource.

**Test plan**
- Check whether `/share` works (in Swagger)
- Check if Upload view loads correctly

