### PR TITLE
Refactor ShowObjectPresenter to Link for tabs

### DIFF
--- a/malwarefront/src/components/ShowObjectPresenter.js
+++ b/malwarefront/src/components/ShowObjectPresenter.js
@@ -17,14 +17,14 @@ export default class ShowObjectPresenter extends Component {
     
     defaultTab = "details"
 
-    setCurrentTab(tab, subtab) {
+    getCurrentTab(tab, subtab) {
         let pathElements = this.props.history.location.pathname.split("/");
         let newPath = pathElements.slice(0, 3).concat([tab]).concat(subtab ? [subtab] : []).join("/");
-        this.props.history.replace(newPath);
+        return newPath
     }
 
     setCurrentSubTab(subtab) {
-        return this.setCurrentTab(this.currentTab, subtab);
+        return this.getCurrentTab(this.currentTab, subtab);
     }
 
     get currentTab() {
@@ -88,9 +88,8 @@ export default class ShowObjectPresenter extends Component {
         let ObjectTab = (props) => {
             return (
                 <li className="nav-item">
-                    <Link to="#" 
-                          className={`nav-link ${this.currentTab === props.tab ? "active" : ""}`} 
-                          onClick={(ev) => { ev.preventDefault(); this.setCurrentTab(props.tab);}}>
+                    <Link to={this.getCurrentTab(props.tab)}
+                          className={`nav-link ${this.currentTab === props.tab ? "active" : ""}`}>
                         { props.icon ? <FontAwesomeIcon icon={props.icon} pull="left" size="1x"/> : [] }
                         { props.label || capitalize(props.tab) }
                     </Link>

--- a/malwarefront/src/components/ShowObjectPresenter.js
+++ b/malwarefront/src/components/ShowObjectPresenter.js
@@ -17,14 +17,10 @@ export default class ShowObjectPresenter extends Component {
     
     defaultTab = "details"
 
-    getCurrentTab(tab, subtab) {
+    getTabLink(tab, subtab) {
         let pathElements = this.props.history.location.pathname.split("/");
         let newPath = pathElements.slice(0, 3).concat([tab]).concat(subtab ? [subtab] : []).join("/");
         return newPath
-    }
-
-    setCurrentSubTab(subtab) {
-        return this.getCurrentTab(this.currentTab, subtab);
     }
 
     get currentTab() {
@@ -62,7 +58,7 @@ export default class ShowObjectPresenter extends Component {
                 {label: "Download", icon: "download", action: (() => this.handleDownload())}
             ],
             relations: [
-                {label: "zoom", icon: "search", action: (() => this.props.history.push("/relations?node[]=" + this.props.id))}
+                {label: "zoom", icon: "search", link: "/relations?node[]=" + this.props.id}
             ],
             preview: [
                 {label: "Download", icon: "download", action: (() => this.handleDownload())}
@@ -88,7 +84,7 @@ export default class ShowObjectPresenter extends Component {
         let ObjectTab = (props) => {
             return (
                 <li className="nav-item">
-                    <Link to={this.getCurrentTab(props.tab)}
+                    <Link to={this.getTabLink(props.tab)}
                           className={`nav-link ${this.currentTab === props.tab ? "active" : ""}`}>
                         { props.icon ? <FontAwesomeIcon icon={props.icon} pull="left" size="1x"/> : [] }
                         { props.label || capitalize(props.tab) }
@@ -100,9 +96,10 @@ export default class ShowObjectPresenter extends Component {
         let ObjectAction = (props) => {
             return (
                 <li className="nav-item">
-                    <Link to="#" 
+                    <Link to={props.link ? props.link : "#"}
                           className="nav-link" 
-                          onClick={(ev) => {ev.preventDefault(); props.action()}}>
+                          onClick={(ev) => {props.action && props.action()}}
+                         >
                         { props.icon ? <FontAwesomeIcon icon={props.icon} pull="left" size="1x"/> : [] }
                         { capitalize(props.label) }
                     </Link>

--- a/malwarefront/src/components/ShowObjectPresenter.js
+++ b/malwarefront/src/components/ShowObjectPresenter.js
@@ -98,7 +98,7 @@ export default class ShowObjectPresenter extends Component {
                 <li className="nav-item">
                     <Link to={props.link ? props.link : "#"}
                           className="nav-link" 
-                          onClick={(ev) => {props.action && props.action()}}
+                          onClick={() => props.action && props.action()}
                          >
                         { props.icon ? <FontAwesomeIcon icon={props.icon} pull="left" size="1x"/> : [] }
                         { capitalize(props.label) }

--- a/malwarefront/src/components/ShowSample.js
+++ b/malwarefront/src/components/ShowSample.js
@@ -122,7 +122,7 @@ class SamplePresenter extends ShowObjectPresenter {
             preview: [
                 (this.currentSubTab === "hex" 
                  ? {label: "Raw view", link: this.getTabLink("preview","raw")}
-                 : {label: "Hex view", link: this.getTabLink("preview","raw")})
+                 : {label: "Hex view", link: this.getTabLink("preview","hex")})
             ],
             config: [
                 {label: "Go to config", action: () => this.props.history.push("/config/"+this.props.latest_config.id)}

--- a/malwarefront/src/components/ShowSample.js
+++ b/malwarefront/src/components/ShowSample.js
@@ -117,12 +117,12 @@ class SamplePresenter extends ShowObjectPresenter {
     get actions() {
         let sampleActions = {
             details: (this.props.canAddParent ? [
-                {label: "Add child", icon: "plus", action: (() => this.props.history.push("/upload?parent="+this.props.id))}
+                {label: "Add child", icon: "plus", link: "/upload?parent="+this.props.id}
             ] : []),
             preview: [
                 (this.currentSubTab === "hex" 
-                 ? {label: "Raw view", action: (() => this.setCurrentSubTab("raw"))}
-                 : {label: "Hex view", action: (() => this.setCurrentSubTab("hex"))})
+                 ? {label: "Raw view", link: this.getTabLink("preview","raw")}
+                 : {label: "Hex view", link: this.getTabLink("preview","raw")})
             ],
             config: [
                 {label: "Go to config", action: () => this.props.history.push("/config/"+this.props.latest_config.id)}


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)

**What is the current behaviour?**
Replace path in props

**What is the new behaviour?**
use Link component to navigate to the new tab

**Closing issues**

closes #18 
