### PR TITLE
Avoid fetching all tagged objects during tag add/remove operation

### DIFF
--- a/model/object.py
+++ b/model/object.py
@@ -300,15 +300,14 @@ class Object(db.Model):
         db_tag, is_new_tag = Tag.get_or_create(db_tag)
 
         try:
-            if self not in db_tag.objects:
-                db_tag.objects.append(self)
-                db.session.add(db_tag)
+            if db_tag not in self.tags:
+                self.tags.append(db_tag)
                 db.session.flush()
                 db.session.commit()
                 return True
         except IntegrityError:
-            db.session.refresh(db_tag)
-            if self not in db_tag.objects:
+            db.session.refresh(self)
+            if db_tag not in self.tags:
                 raise
         return False
 
@@ -325,15 +324,14 @@ class Object(db.Model):
             db_tag = db_tag.one()
 
         try:
-            if self in db_tag.objects:
-                db_tag.objects.remove(self)
-                db.session.add(db_tag)
+            if db_tag in self.tags:
+                self.tags.remove(db_tag)
                 db.session.flush()
                 db.session.commit()
                 return True
         except IntegrityError:
-            db.session.refresh(db_tag)
-            if self in db_tag.objects:
+            db.session.refresh(self)
+            if db_tag in self.tags:
                 raise
         return False
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

Tag adding/removing is very slow for popular tags. Processing time looks to be linearly dependent on count of tagged samples

Malwarecage performs check whether tag was already added/removed by concurrent request. Unfortunately, check is implemented by condition `self in db_tag.objects` which fetches **all tagged objects** on `db_tag.objects` attribute access (lazy-loaded by SQLAlchemy).

This additional query is too broad (because we should ask only for relationship with tagged object) and completely unnecessary because tag information is already fetched by joined relationship defined in Object entity.

```python
class Object(db.Model):
    __tablename__ = 'object'

    ...
    tags = db.relationship('Tag', secondary=object_tag_table, back_populates='objects', lazy='joined')
```

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

We can avoid excessive query by switching the logic in `Object.add_tag` and `Object_remove_tag` methods. 

Instead of operating on `Tag.objects`, we should operate on `Object.tags` relationship.

This will also fix the refresh logic after `IntegrityError`.

**Test plan**
<!-- Explain how to test your changes -->
- Potential regression should be covered by automated e2e tests
- Check whether adding/removing tags works correctly (including already added/removed tags)

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

