### PR TITLE
Max length password validation

### DIFF
--- a/malwarefront/src/components/UserSetPassword.js
+++ b/malwarefront/src/components/UserSetPassword.js
@@ -40,7 +40,7 @@ class UserSetPassword extends Component {
             if (this.state.password !== this.state.repeatPassword) {
                 repeatPasswordElement.setCustomValidity("Passwords doesn't match")
             } else if (encoder.encode(this.state.repeatPassword).length > 72) {
-                repeatPasswordElement.setCustomValidity("The password should contain 72 bytes of UTF-8 characters, your password is too long.")
+                repeatPasswordElement.setCustomValidity("The password should contain no more than 72 bytes of UTF-8 characters, your password is too long.")
             } else {
                 repeatPasswordElement.setCustomValidity("")
             }

--- a/malwarefront/src/components/UserSetPassword.js
+++ b/malwarefront/src/components/UserSetPassword.js
@@ -36,7 +36,6 @@ class UserSetPassword extends Component {
             dirty: true
         }, () => {
             const encoder = new TextEncoder()
-
             let repeatPasswordElement = $("#repeatPassword")[0]
             if (this.state.password !== this.state.repeatPassword) {
                 repeatPasswordElement.setCustomValidity("Passwords doesn't match")

--- a/malwarefront/src/components/UserSetPassword.js
+++ b/malwarefront/src/components/UserSetPassword.js
@@ -35,11 +35,19 @@ class UserSetPassword extends Component {
             [name]: value,
             dirty: true
         }, () => {
+            const encoder = new TextEncoder()
+
             let repeatPasswordElement = $("#repeatPassword")[0]
-            if(this.state.password !== this.state.repeatPassword)
+            if(this.state.password !== this.state.repeatPassword) {
                 repeatPasswordElement.setCustomValidity("Passwords doesn't match")
-            else
+            }
+            else if (encoder.encode(this.state.repeatPassword).length > 72) {
+                repeatPasswordElement.setCustomValidity("The password should contain 72 bytes of UTF-8 characters, your password is too long.")
+                // this.setState({error: "The password should contain 72 bytes of UTF-8 characters, your password is too long."})
+            }
+            else {
                 repeatPasswordElement.setCustomValidity("")
+            }
         });
     }
 
@@ -69,13 +77,13 @@ class UserSetPassword extends Component {
                 <form onSubmit={this.handleSubmit}>
                     <div className="form-group">
                         <label>New password</label>
-                        <input type="password" minlength="8" name="password" value={this.state.password}
+                        <input type="password" minLength="8" name="password" value={this.state.password}
                                onChange={this.handleInputChange} className="form-control" required
                                disabled={this.state.success}/>
                     </div>
                     <div className="form-group">
                         <label>Repeat new password</label>
-                        <input type="password" minlength="8" name="repeatPassword" value={this.state.repeatPassword}
+                        <input type="password" minLength="8" name="repeatPassword" value={this.state.repeatPassword}
                                id="repeatPassword" onChange={this.handleInputChange} className="form-control" 
                                required disabled={this.state.success}/>
                     </div>

--- a/malwarefront/src/components/UserSetPassword.js
+++ b/malwarefront/src/components/UserSetPassword.js
@@ -38,14 +38,11 @@ class UserSetPassword extends Component {
             const encoder = new TextEncoder()
 
             let repeatPasswordElement = $("#repeatPassword")[0]
-            if(this.state.password !== this.state.repeatPassword) {
+            if (this.state.password !== this.state.repeatPassword) {
                 repeatPasswordElement.setCustomValidity("Passwords doesn't match")
-            }
-            else if (encoder.encode(this.state.repeatPassword).length > 72) {
+            } else if (encoder.encode(this.state.repeatPassword).length > 72) {
                 repeatPasswordElement.setCustomValidity("The password should contain 72 bytes of UTF-8 characters, your password is too long.")
-                // this.setState({error: "The password should contain 72 bytes of UTF-8 characters, your password is too long."})
-            }
-            else {
+            } else {
                 repeatPasswordElement.setCustomValidity("")
             }
         });
@@ -55,7 +52,7 @@ class UserSetPassword extends Component {
         event.preventDefault();
         try {
             let response = await api.authSetPassword(this.props.match.params.token, this.state.password)
-            this.setState({success: response.data.login});
+            this.setState({success: response.data.login, error: null});
         } catch(error) {
             this.setState({...this.initialState, error});
         }

--- a/resources/auth.py
+++ b/resources/auth.py
@@ -244,6 +244,7 @@ class UserChangePasswordResource(Resource):
                 description: When set password token is no longer valid
         """
         MIN_PASSWORD_LENGTH = 8
+        MAX_PASSWORD_LENGHT = 72 #UTF-8 bytes
         schema = UserSetPasswordSchema()
         obj = schema.loads(request.get_data(as_text=True))
         if obj.errors:
@@ -256,6 +257,8 @@ class UserChangePasswordResource(Resource):
             raise BadRequest("Empty password is not allowed")
         if len(password) < MIN_PASSWORD_LENGTH:
             raise BadRequest("Password is too short")
+        if len(password.encode()) > MAX_PASSWORD_LENGHT:
+            raise BadRequest("The password should contain 72 bytes of UTF-8 characters, your password is too long.")
 
         user.set_password(password)
         db.session.add(user)

--- a/resources/auth.py
+++ b/resources/auth.py
@@ -258,7 +258,7 @@ class UserChangePasswordResource(Resource):
         if len(password) < MIN_PASSWORD_LENGTH:
             raise BadRequest("Password is too short")
         if len(password.encode()) > MAX_PASSWORD_LENGTH:
-            raise BadRequest("The password should contain 72 bytes of UTF-8 characters, your password is too long.")
+            raise BadRequest("The password should contain no more than 72 bytes of UTF-8 characters, your password is too long.")
 
         user.set_password(password)
         db.session.add(user)

--- a/resources/auth.py
+++ b/resources/auth.py
@@ -244,7 +244,7 @@ class UserChangePasswordResource(Resource):
                 description: When set password token is no longer valid
         """
         MIN_PASSWORD_LENGTH = 8
-        MAX_PASSWORD_LENGTH = 72 #UTF-8 bytes
+        MAX_PASSWORD_LENGTH = 72  #UTF-8 bytes
         schema = UserSetPasswordSchema()
         obj = schema.loads(request.get_data(as_text=True))
         if obj.errors:

--- a/resources/auth.py
+++ b/resources/auth.py
@@ -244,7 +244,7 @@ class UserChangePasswordResource(Resource):
                 description: When set password token is no longer valid
         """
         MIN_PASSWORD_LENGTH = 8
-        MAX_PASSWORD_LENGHT = 72 #UTF-8 bytes
+        MAX_PASSWORD_LENGTH = 72 #UTF-8 bytes
         schema = UserSetPasswordSchema()
         obj = schema.loads(request.get_data(as_text=True))
         if obj.errors:
@@ -257,7 +257,7 @@ class UserChangePasswordResource(Resource):
             raise BadRequest("Empty password is not allowed")
         if len(password) < MIN_PASSWORD_LENGTH:
             raise BadRequest("Password is too short")
-        if len(password.encode()) > MAX_PASSWORD_LENGHT:
+        if len(password.encode()) > MAX_PASSWORD_LENGTH:
             raise BadRequest("The password should contain 72 bytes of UTF-8 characters, your password is too long.")
 
         user.set_password(password)


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)

**What is the current behaviour?**
Malwarecage allows to set longer password than 72 bytes but only the first 72 bytes are considered during authentication.

**What is the new behaviour?**
Limit user to set maximum 72 bytes password.

**Test plan**
Set long password (>72 b)

**Closing issues**

closes #49 