### PR TITLE
Fix 'e.props.tagClick is not a function' after clicking tag in object view

### DIFF
--- a/malwarefront/src/components/Tag.js
+++ b/malwarefront/src/components/Tag.js
@@ -21,12 +21,13 @@ export class Tag extends Component {
                       onMouseEnter={this.onMouseEnter} 
                       onMouseLeave={this.onMouseLeave}>
                     {
-                        this.props.searchable ?
+                        this.props.searchable ? (
                             <Link to={makeSearchLink("tag", this.props.tag, false, this.props.searchEndpoint)}
                                   className="tag-link"
-                                  onClick={ev => this.props.tagClick(ev, this.props.tag)}>{this.props.tag}</Link>
-                            :
+                                  onClick={ev => this.props.tagClick && this.props.tagClick(ev, this.props.tag)}>{this.props.tag}</Link>
+                        ) : (
                             <span>{this.props.tag}</span>
+                        )
                     }
                     {
                         (this.props.deletable || this.props.filterable) &&


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
- Clicking on tag in object view throws exception `e.props.tagClick is not a function` and does nothing

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

- Clicking on tag redirects to `Recent <object_type>` view with `tag:<tag>` query
- `tagClick` property is optional, so we should check first whether callback is set

**Test plan**
<!-- Explain how to test your changes -->
- Click on tag in object view and check if it works

**Closing issues**

closes #55
