### PR TITLE
Remove all:unset from tag's CSS style

### DIFF
--- a/malwarefront/src/components/Tag.js
+++ b/malwarefront/src/components/Tag.js
@@ -23,14 +23,14 @@ export class Tag extends Component {
                     {
                         this.props.searchable ?
                             <Link to={makeSearchLink("tag", this.props.tag, false, this.props.searchEndpoint)}
-                                  style={{all: "unset", cursor: "pointer"}}
+                                  className="tag-link"
                                   onClick={ev => this.props.tagClick(ev, this.props.tag)}>{this.props.tag}</Link>
                             :
                             <span>{this.props.tag}</span>
                     }
                     {
                         (this.props.deletable || this.props.filterable) &&
-                        <a style={{all: "unset", cursor: "pointer"}} 
+                        <a className="tag-link"
                            href="#tag"
                            onClick={ev => this.props.tagRemove(ev, this.props.tag)}>
                             <FontAwesomeIcon icon={this.props.filterable ? "ban" : "times"} pull="right" size="1x"/>

--- a/malwarefront/src/styles/index.css
+++ b/malwarefront/src/styles/index.css
@@ -228,6 +228,12 @@ a.blob {
     display: inline-block;
 }
 
+.tag-link, .tag-link:hover {
+    cursor: pointer;
+    color: inherit;
+    text-decoration: none;
+}
+
 .not-expanded-node > g.label:hover {
     transform: scale(1.1);
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

- Tag uses "all: unset" to override default `<a>` styling, which doesn't work correctly on Chromium and renders to something horrible.

![image](https://user-images.githubusercontent.com/8720367/86029237-2da35a00-ba33-11ea-997c-96f8ca2e5e67.png)

**What is the new behaviour?**
- Applied correct styling to make related `<a>` elements look like regular text without underline and blueish color.

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->

closes #54
