### PR TITLE
Fixed various glitches related with redirect on successful login

### DIFF
--- a/malwarefront/src/commons/auth/actions.js
+++ b/malwarefront/src/commons/auth/actions.js
@@ -12,7 +12,7 @@ function login(username, password, prevLocation) {
                 dispatch(push(prevLocation || "/"));
             })
             .catch(err => {
-                // Error is unclonable and we can't directly put it in state
+                // Error is unclonable and we can't directly put it in location state
                 // We need to extract response data part
                 let error = { response: { data: err.response.data } };
                 dispatch({ type: authActionTypes.LOGIN_FAILURE});

--- a/malwarefront/src/commons/auth/actions.js
+++ b/malwarefront/src/commons/auth/actions.js
@@ -3,21 +3,26 @@ import authService from "./service";
 
 import { push } from "connected-react-router";
 
-function login(username, password, navPath) {
+function login(username, password, prevLocation) {
     return dispatch => {
         dispatch({ type: authActionTypes.LOGIN_REQUEST, username })
         authService.login(username, password)
             .then(user => {
-                dispatch({ type: authActionTypes.LOGIN_SUCCESS, user: user, navPath: null });
-                dispatch(push(navPath || "/"));
+                dispatch({ type: authActionTypes.LOGIN_SUCCESS, user: user, prevLocation: null });
+                dispatch(push(prevLocation || "/"));
             })
             .catch(error => dispatch({ type: authActionTypes.LOGIN_FAILURE, error }))
     }
 }
 
-function logout(error, navPath) {
-    authService.logout();
-    return { type: authActionTypes.LOGOUT, error, navPath };
+function logout(error, prevLocation) {
+    return dispatch => {
+        authService.logout();
+        if(prevLocation && prevLocation.pathname === "/login")
+            prevLocation = null;
+        dispatch({ type: authActionTypes.LOGOUT, error, prevLocation });
+        dispatch(push("/login"))
+    }
 }
 
 export default { login, logout };

--- a/malwarefront/src/commons/auth/actions.js
+++ b/malwarefront/src/commons/auth/actions.js
@@ -11,17 +11,20 @@ function login(username, password, prevLocation) {
                 dispatch({ type: authActionTypes.LOGIN_SUCCESS, user: user, prevLocation: null });
                 dispatch(push(prevLocation || "/"));
             })
-            .catch(error => dispatch({ type: authActionTypes.LOGIN_FAILURE, error }))
+            .catch(error => {
+                dispatch({ type: authActionTypes.LOGIN_FAILURE})
+                dispatch(push({ pathname: "/login", state: {error} }))
+            })
     }
 }
 
-function logout(error, prevLocation) {
+function logout(state, prevLocation) {
     return dispatch => {
         authService.logout();
         if(prevLocation && prevLocation.pathname === "/login")
             prevLocation = null;
-        dispatch({ type: authActionTypes.LOGOUT, error, prevLocation });
-        dispatch(push("/login"))
+        dispatch({ type: authActionTypes.LOGOUT, prevLocation });
+        dispatch(push({ pathname: "/login", state }))
     }
 }
 

--- a/malwarefront/src/commons/auth/actions.js
+++ b/malwarefront/src/commons/auth/actions.js
@@ -11,9 +11,12 @@ function login(username, password, prevLocation) {
                 dispatch({ type: authActionTypes.LOGIN_SUCCESS, user: user, prevLocation: null });
                 dispatch(push(prevLocation || "/"));
             })
-            .catch(error => {
-                dispatch({ type: authActionTypes.LOGIN_FAILURE})
-                dispatch(push({ pathname: "/login", state: {error} }))
+            .catch(err => {
+                // Error is unclonable and we can't directly put it in state
+                // We need to extract response data part
+                let error = { response: { data: err.response.data } };
+                dispatch({ type: authActionTypes.LOGIN_FAILURE});
+                dispatch(push({ pathname: "/login", state: {error} }));
             })
     }
 }

--- a/malwarefront/src/commons/auth/reducer.js
+++ b/malwarefront/src/commons/auth/reducer.js
@@ -9,7 +9,7 @@ export default function(state, action) {
             return { ...state, loggedUser: action.user, prevLocation: null }
         case authActionTypes.LOGIN_FAILURE:
         case authActionTypes.LOGOUT:
-            return { ...state, loggedUser: undefined, error: action.error, prevLocation: action.prevLocation || state.prevLocation }
+            return { ...state, loggedUser: undefined, prevLocation: action.prevLocation || state.prevLocation }
         default:
             return state;
     }

--- a/malwarefront/src/commons/auth/reducer.js
+++ b/malwarefront/src/commons/auth/reducer.js
@@ -6,10 +6,10 @@ export default function(state, action) {
         return { loggedUser: authService.getAuthenticatedUser() }
     switch(action.type) {
         case authActionTypes.LOGIN_SUCCESS:
-            return { ...state, loggedUser: action.user, navPath: action.navPath }
+            return { ...state, loggedUser: action.user, prevLocation: null }
         case authActionTypes.LOGIN_FAILURE:
         case authActionTypes.LOGOUT:
-            return { ...state, loggedUser: undefined, error: action.error, navPath: action.navPath && (action.navPath.startsWith("/login") ? "/" : action.navPath)}
+            return { ...state, loggedUser: undefined, error: action.error, prevLocation: action.prevLocation || state.prevLocation }
         default:
             return state;
     }

--- a/malwarefront/src/commons/ui/ProtectedRoute.js
+++ b/malwarefront/src/commons/ui/ProtectedRoute.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Route } from 'react-router-dom';
+import { Route } from "react-router-dom";
 import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
 
@@ -13,7 +13,7 @@ function ProtectedRoute(props) {
         if(!props.isAuthenticated)
         {
             props.auth.logout({error: "You need to authenticate before accessing this page."}, history.location);
-            return []
+            return [];
         }
         return (
             props.condition

--- a/malwarefront/src/commons/ui/ProtectedRoute.js
+++ b/malwarefront/src/commons/ui/ProtectedRoute.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Route, Redirect } from 'react-router-dom';
+import { Route } from 'react-router-dom';
 import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
 
@@ -12,9 +12,9 @@ function ProtectedRoute(props) {
     let routeRender = (renderProps) => {
         if(!props.isAuthenticated)
         {
-            props.auth.logout(null, history.location.pathname);
-            return <Redirect to="/login" />
-        }    
+            props.auth.logout("You need to authenticate before accessing this page.", history.location);
+            return []
+        }
         return (
             props.condition
             ? <props.component {...renderProps} />

--- a/malwarefront/src/commons/ui/ProtectedRoute.js
+++ b/malwarefront/src/commons/ui/ProtectedRoute.js
@@ -12,7 +12,7 @@ function ProtectedRoute(props) {
     let routeRender = (renderProps) => {
         if(!props.isAuthenticated)
         {
-            props.auth.logout("You need to authenticate before accessing this page.", history.location);
+            props.auth.logout({error: "You need to authenticate before accessing this page."}, history.location);
             return []
         }
         return (

--- a/malwarefront/src/components/Navigation.js
+++ b/malwarefront/src/components/Navigation.js
@@ -46,7 +46,7 @@ class Navigation extends Component {
 
     handleLogout = (event) => {
         event.preventDefault();
-        this.props.auth.logout("User logged out successfully.");
+        this.props.auth.logout({success: "User logged out successfully."});
     }
 
     render() {

--- a/malwarefront/src/components/Navigation.js
+++ b/malwarefront/src/components/Navigation.js
@@ -46,7 +46,7 @@ class Navigation extends Component {
 
     handleLogout = (event) => {
         event.preventDefault();
-        this.props.auth.logout();
+        this.props.auth.logout("User logged out successfully.");
     }
 
     render() {

--- a/malwarefront/src/components/UserLogin.js
+++ b/malwarefront/src/components/UserLogin.js
@@ -25,7 +25,7 @@ class UserLogin extends Component {
 
     handleSubmit = (event) => {
         event.preventDefault();
-        this.props.auth.login(this.state.login, this.state.password, this.props.navPath);
+        this.props.auth.login(this.state.login, this.state.password, this.props.prevLocation);
     }
 
     render() {
@@ -59,7 +59,7 @@ class UserLogin extends Component {
 function mapStateToProps(state) {
     return {
         error: state.auth.error,
-        navPath: state.auth.navPath
+        prevLocation: state.auth.prevLocation
     }
 }
 

--- a/malwarefront/src/components/UserLogin.js
+++ b/malwarefront/src/components/UserLogin.js
@@ -29,8 +29,9 @@ class UserLogin extends Component {
     }
 
     render() {
+        let {error, success} = this.props.location.state || {};
         return (
-            <View ident="userLogin" error={this.props.error}>
+            <View ident="userLogin" error={error} success={success}>
                 <h2>Login</h2>
                 <form onSubmit={this.handleSubmit}>
                     <Extension ident="userLoginNote" />
@@ -58,7 +59,6 @@ class UserLogin extends Component {
 
 function mapStateToProps(state) {
     return {
-        error: state.auth.error,
         prevLocation: state.auth.prevLocation
     }
 }

--- a/malwarefront/src/store.js
+++ b/malwarefront/src/store.js
@@ -46,7 +46,7 @@ api.axios.interceptors.response.use(_=>_, error =>
 {
     if (error.response && error.response.status === 401)
     {
-        store.dispatch(authActions.logout(error.response.data.message, history.location.pathname))
+        store.dispatch(authActions.logout("Session expired. Please authenticate before accessing this page", history.location))
     }
     return Promise.reject(error)
 });

--- a/malwarefront/src/store.js
+++ b/malwarefront/src/store.js
@@ -46,7 +46,7 @@ api.axios.interceptors.response.use(_=>_, error =>
 {
     if (error.response && error.response.status === 401)
     {
-        store.dispatch(authActions.logout("Session expired. Please authenticate before accessing this page", history.location))
+        store.dispatch(authActions.logout({error: "Session expired. Please authenticate before accessing this page"}, history.location))
     }
     return Promise.reject(error)
 });


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
- Redirect to target page after session expiration not always works
- Query/hash part of path is trimmed, only path is stored in Redux state

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
- Renamed `navPath` to `prevLocation`
- All redirects to `/login` page and back to the target are handled by `authActions`
- Whole `history.location` object is passed to Redux state, not only the pathname part. This should preserve all location parts: pathname, query, hash and state
- Trying not to override the `prevLocation` by subsequent `logout` calls, triggered both by `HTTP 401` handler and ProtectedRoute
- Messages viewed in `/login` page are no longer a part of Redux state, they're moved to location state.

**Test plan**
<!-- Explain how to test your changes -->
- Login and logout. You should see `User logged out successfully.`
- Login, duplicate tab, set capability for admin in http://127.0.0.1/group/admin, and come back to previous tab to navigate. After navigation - you should see `Session expired. Please authenticate before accessing this page`. After successful log in: you should go to the target page.
- Login, go to expanded, zoomed relations view, store the URL and logout. Navigate to stored URL, you should see `You need to authenticate before accessing this page`. Try to log in, app should come back to the path you navigated before.
- Try to login with wrong password (403)
- Try to use incorrect login `asdasdasd$#@$?_^%$` (400)

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->

closes #25, closes #26
