### PR TITLE
Bump ssdeep and don't build it manually - use BUILD_LIB=1

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -6,7 +6,7 @@ RUN apk add --no-cache postgresql-client postgresql-dev libmagic
 
 COPY requirements.txt /tmp/requirements.txt
 RUN apk add --no-cache -t build libffi libffi-dev py3-cffi build-base python3-dev automake m4 autoconf libtool \
-    && cd /tmp && BUILD_LIB=1 pip --no-cache-dir install -r requirements.txt \
+    && BUILD_LIB=1 pip --no-cache-dir install -r /tmp/requirements.txt \
     && apk del build
 
 # Install plugin requirements 

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -5,15 +5,8 @@ LABEL maintainer="info@cert.pl"
 RUN apk add --no-cache postgresql-client postgresql-dev libmagic
 
 COPY requirements.txt /tmp/requirements.txt
-RUN apk add --no-cache -t build libffi libffi-dev py3-cffi build-base python3-dev automake m4 perl autoconf libtool \
-    && wget -O /tmp/ssdeep.tar.gz https://github.com/ssdeep-project/ssdeep/releases/download/release-2.14.1/ssdeep-2.14.1.tar.gz \
-    && cd /tmp \
-    && tar -xopf /tmp/ssdeep.tar.gz \
-    && cd ssdeep-2.14.1 \
-    && ./configure \
-    && make \
-    && make install \
-    && cd /tmp && pip --no-cache-dir install -r requirements.txt \
+RUN apk add --no-cache -t build libffi libffi-dev py3-cffi build-base python3-dev automake m4 autoconf libtool \
+    && cd /tmp && BUILD_LIB=1 pip --no-cache-dir install -r requirements.txt \
     && apk del build
 
 # Install plugin requirements 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ Flask-Migrate==2.5.3
 Flask-RESTful==0.3.6
 SQLAlchemy==1.3.18
 marshmallow==2.15.6
-ssdeep==3.3
+ssdeep==3.4
 psycopg2-binary==2.8.5
 requests==2.24.0
 apispec[yaml,validation]==3.3.1


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
- ssdeep is built by downloading the sources directly from ssdeep-project instead of using BUILD_LIB option during installation of python-ssdeep library

**What is the new behaviour?**
- Bumped ssdeep to 3.4
- Used BUILD_LIB=1
