### PR TITLE
Removed tiangolo in mwdb, used native uwsgi http-socket instead

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -50,4 +50,4 @@ RUN mkdir -p /app/uploads/ && \
 ENV PYTHONPATH=/app
 WORKDIR /app
 
-CMD ["/bin/sh", "/app/start.sh"]
+CMD ["/app/start.sh"]

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM tiangolo/uwsgi-nginx-flask:python3.6-alpine3.8
+FROM python:3.6-alpine
 
 LABEL maintainer="info@cert.pl"
 
@@ -25,7 +25,7 @@ RUN ls /tmp/requirements-*.txt | xargs -i,, pip --no-cache-dir install -r ,,
 
 # Copy backend files
 
-COPY prestart.sh uwsgi.ini plugin_engine.py app.py version.py /app/
+COPY start.sh uwsgi.ini plugin_engine.py app.py version.py /app/
 
 COPY core /app/core
 COPY migrations /app/migrations
@@ -46,3 +46,8 @@ RUN mkdir -p /app/uploads/ && \
     chmod o=rX -R /app && \
     chmod 700 /app/uploads/ && \
     chown nobody:nobody /app/uploads/
+
+ENV PYTHONPATH=/app
+WORKDIR /app
+
+CMD ["/bin/sh", "/app/start.sh"]

--- a/deploy/docker/Dockerfile-web
+++ b/deploy/docker/Dockerfile-web
@@ -10,7 +10,7 @@ RUN cd /app \
 
 FROM nginx:stable
 
-ENV PROXY_BACKEND_URL http://mwdb./
+ENV PROXY_BACKEND_URL http://mwdb.:8080/
 
 COPY malwarefront/default.conf.template /etc/nginx/conf.d/default.conf.template
 COPY malwarefront/start.sh /start.sh

--- a/deploy/docker/Dockerfile-web-dev
+++ b/deploy/docker/Dockerfile-web-dev
@@ -8,7 +8,7 @@ RUN cd /app \
     && CI=true npm run build \
     && npm cache clean --force
 
-ENV PROXY_BACKEND_URL http://mwdb./
+ENV PROXY_BACKEND_URL http://mwdb.:8080/
 
 WORKDIR /app
 CMD ["npm", "run", "start"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Werkzeug==0.15.2
+uwsgi==2.0.19.1
 alembic==1.0.10
 Flask==1.0.2
 Flask-SQLAlchemy==2.3.2

--- a/start.sh
+++ b/start.sh
@@ -17,4 +17,4 @@ else
     flask create_admin --require-empty "$MALWARECAGE_ADMIN_LOGIN" "$MALWARECAGE_ADMIN_EMAIL" "$MALWARECAGE_ADMIN_PASSWORD"
 fi
 
-uwsgi --ini /app/uwsgi.ini
+exec uwsgi --ini /app/uwsgi.ini

--- a/start.sh
+++ b/start.sh
@@ -16,3 +16,5 @@ else
     echo "Creating initial admin account..."
     flask create_admin --require-empty "$MALWARECAGE_ADMIN_LOGIN" "$MALWARECAGE_ADMIN_EMAIL" "$MALWARECAGE_ADMIN_PASSWORD"
 fi
+
+uwsgi --ini /app/uwsgi.ini

--- a/tests/backend/Dockerfile
+++ b/tests/backend/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.6
-ENV MWDB_URL http://mwdb.
+ENV MWDB_URL http://mwdb.:8080/
 COPY requirements.txt /app/requirements.txt
 RUN pip3 install -r /app/requirements.txt
 COPY *.py /app/

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -2,3 +2,14 @@
 module = app
 callable = app
 uid = nobody
+# HTTP socket
+http-socket = :8080
+# Graceful shutdown on SIGTERM, see https://github.com/unbit/uwsgi/issues/849#issuecomment-118869386
+hook-master-start = unix_signal:15 gracefully_kill_them_all
+need-app = true
+die-on-term = true
+# For debugging and testing
+show-config = true
+# Default cheaper settings
+cheaper = 2
+processes = 16

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -8,8 +8,3 @@ http-socket = :8080
 hook-master-start = unix_signal:15 gracefully_kill_them_all
 need-app = true
 die-on-term = true
-# For debugging and testing
-show-config = true
-# Default cheaper settings
-cheaper = 2
-processes = 16


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
- Production environment contains two, differently configured nginx services - first in `mwdb` from tiangolo, second in `malwarefront` serving static web application and routing `/api` endpoint

**What is the new behaviour?**
- `mwdb` uses uWSGI's native support for HTTP (http-socket https://uwsgi-docs.readthedocs.io/en/latest/HTTP.html)
- `malwarefront` stays the same:
    - nginx serves backend API proxy (`/api`) and static files for web application
    - development environment does the same using webpack-dev-server and http-proxy-middleware

Files containing the uWSGI configuration in `tiangolo/uwsgi-nginx` (base for `tiangolo/uwsgi-nginx-flask`)
- env-based uwsgi configuration: https://github.com/tiangolo/uwsgi-nginx-docker/blob/master/docker-images/python3.6.dockerfile
- `uwsgi.ini`: https://github.com/tiangolo/uwsgi-nginx-docker/blob/master/docker-images/uwsgi.ini
- supervisord uwsgi invocation: https://github.com/tiangolo/uwsgi-nginx-docker/blob/master/docker-images/supervisord-alpine.ini

