### PR TITLE
Parametrize frontend tests and add to the workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,8 +55,8 @@ jobs:
         with:
           name: malwarecage-web-image
           path: malwarecage-web-image
-  build_e2e:
-    name: Build e2e test image
+  build_backend_e2e:
+    name: Build backend e2e test image
     runs-on: ubuntu-latest
     env:
       DOCKER_BUILDKIT: 1
@@ -80,9 +80,34 @@ jobs:
         with:
           name: malwarecage-tests-image
           path: malwarecage-tests-image
-  test_e2e:
-    needs: [build_core, build_frontend, build_e2e] 
-    name: Perform e2e tests
+  build_frontend_e2e:
+    name: Build frontend e2e test image
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_BUILDKIT: 1
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+      - name: Build and push test image
+        uses: docker/build-push-action@v1.1.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          dockerfile: ./tests/frontend/Dockerfile
+          repository: certpl/malwarecage-web-tests
+          path: tests/frontend
+          tags: ${{ github.sha }}
+          push: ${{ github.event == 'push' }}
+      - name: Store test image
+        run: docker save -o ./malwarecage-web-tests-image certpl/malwarecage-web-tests:${{ github.sha }}
+      - name: Upload test image
+        uses: actions/upload-artifact@v2
+        with:
+          name: malwarecage-web-tests-image
+          path: malwarecage-web-tests-image
+  test_backend_e2e:
+    needs: [build_core, build_frontend, build_backend_e2e]
+    name: Perform backend e2e tests
     runs-on: ubuntu-latest
     env:
       DOCKER_BUILDKIT: 1
@@ -105,6 +130,34 @@ jobs:
           ./gen_vars.sh test
       - name: Perform tests
         run: |
-          docker-compose -f docker-compose-e2e.yml up -d
+          docker-compose -f docker-compose-e2e.yml up -d mwdb-tests
           docker-compose -f docker-compose-e2e.yml logs -f -t mwdb-tests
           docker wait malwarecage_mwdb-tests_1
+  test_frontend_e2e:
+    needs: [build_core, build_frontend, build_frontend_e2e]
+    name: Perform frontend e2e tests
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_BUILDKIT: 1
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+      - name: Download all artifacts
+        uses: actions/download-artifact@v2
+      - name: Import images
+        run: |
+          docker load --input ./malwarecage-image/malwarecage-image
+          docker load --input ./malwarecage-web-image/malwarecage-web-image
+          docker load --input ./malwarecage-web-tests-image/malwarecage-web-tests-image
+          docker tag certpl/malwarecage:$GITHUB_SHA certpl/malwarecage:latest
+          docker tag certpl/malwarecage-web:$GITHUB_SHA certpl/malwarecage-web:latest
+          docker tag certpl/malwarecage-web-tests:$GITHUB_SHA certpl/malwarecage-web-tests:latest
+      - name: Setup configuration
+        run: |
+          chmod +x gen_vars.sh
+          ./gen_vars.sh test
+      - name: Perform tests
+        run: |
+          docker-compose -f docker-compose-e2e.yml up -d web-tests
+          docker-compose -f docker-compose-e2e.yml logs -f -t web-tests
+          docker wait malwarecage_web-tests_1

--- a/docker-compose-e2e.yml
+++ b/docker-compose-e2e.yml
@@ -32,13 +32,18 @@ services:
       - postgres-vars.env
   mwdb-tests:
     build: tests/backend
+    depends_on:
+      - mwdb
     image: certpl/malwarecage-tests
     env_file:
       - mwdb-vars.env
-  frontend-tests:
+  web-tests:
     build: tests/frontend
     depends_on:
       - mwdb
       - malwarefront
+    image: certpl/malwarecage-web-tests
+    env_file:
+      - mwdb-vars.env
   redis:
     image: redis:alpine

--- a/tests/frontend/Dockerfile
+++ b/tests/frontend/Dockerfile
@@ -1,9 +1,9 @@
 FROM cypress/base:10
 
-COPY . /app/
-
 WORKDIR /app
-
+COPY package.json /app/package.json
 RUN npm install
 
-CMD ["npm","run","test"]
+COPY . /app/
+
+CMD ["npm", "run", "test"]

--- a/tests/frontend/cypress/integration/login.js
+++ b/tests/frontend/cypress/integration/login.js
@@ -10,8 +10,8 @@ describe('Login test - Malwarecage', function() {
            .should('have.value', 'admin')
 
        cy.get(':nth-child(2) > .form-control')
-           .type('Your password')
-           .should('have.value', 'Your password')
+           .type(Cypress.env('admin_password'))
+           .should('have.value', Cypress.env('admin_password'))
 
        cy.contains('Submit').click()
        cy.contains('Logged as: admin')

--- a/tests/frontend/cypress/plugins/index.js
+++ b/tests/frontend/cypress/plugins/index.js
@@ -16,6 +16,7 @@
  * @type {Cypress.PluginConfig}
  */
 module.exports = (on, config) => {
-  // `on` is used to hook into various events Cypress emits
-  // `config` is the resolved Cypress config
+  config.env = config.env || {}
+  config.env.admin_password = process.env.MALWARECAGE_ADMIN_PASSWORD
+  return config
 }


### PR DESCRIPTION
- Parametrize `admin_password` used in test
- Reorder Dockerfile a bit
- Add tests to the workflow

Related with https://github.com/CERT-Polska/malwarecage/pull/66