### PR TITLE
Enable HTTP/1.1 socket and enable master process for uWSGI

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -41,6 +41,10 @@ RUN mkdir -p /app/uploads/ && \
     chown nobody:nobody /app/uploads/
 
 ENV PYTHONPATH=/app
+
+ENV UWSGI_CHEAPER=2
+ENV UWSGI_PROCESSES=16
+
 WORKDIR /app
 
 CMD ["/app/start.sh"]

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -41,10 +41,6 @@ RUN mkdir -p /app/uploads/ && \
     chown nobody:nobody /app/uploads/
 
 ENV PYTHONPATH=/app
-
-ENV UWSGI_CHEAPER=2
-ENV UWSGI_PROCESSES=16
-
 WORKDIR /app
 
 CMD ["/app/start.sh"]

--- a/gen_vars.sh
+++ b/gen_vars.sh
@@ -34,6 +34,7 @@ else
     echo "MALWARECAGE_ENABLE_RATE_LIMIT=1" >> mwdb-vars.env
     echo "MALWARECAGE_ENABLE_REGISTRATION=0" >> mwdb-vars.env
 fi
+echo "UWSGI_PROCESSES=4" >> mwdb-vars.env
 
 echo "POSTGRES_USER=mwdb" > postgres-vars.env
 echo "POSTGRES_DB=mwdb" >> postgres-vars.env

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -3,7 +3,7 @@ module = app
 callable = app
 uid = nobody
 # HTTP socket
-http-socket = :8080
+http11-socket = :8080
 # Graceful shutdown on SIGTERM, see https://github.com/unbit/uwsgi/issues/849#issuecomment-118869386
 hook-master-start = unix_signal:15 gracefully_kill_them_all
 need-app = true

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -5,6 +5,7 @@ uid = nobody
 # HTTP socket
 http11-socket = :8080
 # Graceful shutdown on SIGTERM, see https://github.com/unbit/uwsgi/issues/849#issuecomment-118869386
+master = true
 hook-master-start = unix_signal:15 gracefully_kill_them_all
 need-app = true
 die-on-term = true


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**Current architecture**
- In production env: uWSGI http-socket exposed by `mwdb` is proxied by nginx in `malwarefront` container.
- In development env: http-socket is routed by webpack-dev-server
- In e2e tests: http-socket is used directly by python-requests library.

**Change description**

Default http-socket is not aware of `keep-alive` but still accepts HTTP/1.1 protocol so requests in e2e tests are failing randomly with `Connection reset by peer`. I don't know if `webpack-dev-server` provides a fallback to HTTP/1.0, so it would be more safe just to use `http11-socket` in uWSGI.

`tiangolo/uwsgi-nginx-flask` used uWSGI cheaper subsystem by default (which implicates `master=true`), so we need to enable `master=true` in `uwsgi.ini` as well. 

uWSGI defaults are pretty minimal and should be defined by user, but we still can provide some for Docker environment via `mwdb-vars.env` file.

