### PR TITLE
Hotfix: Missing field during creation of administration account

### DIFF
--- a/app.py
+++ b/app.py
@@ -212,7 +212,9 @@ def create_admin(name, email, password, require_empty):
     group = db.session.query(Group).filter(Group.name == name).first()
 
     try:
-        user = User(login=name, email=email)
+        user = User(login=name,
+                    email=email,
+                    additional_info="Malwarecage built-in administration account")
         user.set_password(password)
         user.version_uid = '0' * 16
         user.identity_ver = '0' * 16


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)

- Added missing `additional_field` during first administration account creation
