### PR TITLE
Case-insensitive mail comparison during password recover

### DIFF
--- a/resources/auth.py
+++ b/resources/auth.py
@@ -3,7 +3,7 @@ import requests
 
 from flask import request, g
 from flask_restful import Resource
-from sqlalchemy import exists
+from sqlalchemy import exists, func
 from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.sql.expression import false
 from werkzeug.exceptions import Forbidden, Conflict, InternalServerError
@@ -317,7 +317,7 @@ class RecoverPasswordResource(Resource):
         try:
             user = User.query.filter(
                 User.login == obj.data['login'],
-                User.email == obj.data['email'],
+                func.lower(User.email) == obj.data['email'].lower(),
                 User.pending == false()
             ).one()
         except NoResultFound:


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
- User e-mail address is treated in case-sensitive manner during password recovery

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
- E-mail address can be stored case-sensitive, but comparison should be case-insensitive.

**Test plan**
<!-- Explain how to test your changes -->
- Register new user
- Try to recover password using uppercased e-mail (http://127.0.0.1/recover_password)
- Check if password recover form accepts e-mail with different case combination
