### PR TITLE
Respect 'type' argument in generic endpoints + case insensitive identifier

### DIFF
--- a/core/service.py
+++ b/core/service.py
@@ -139,7 +139,7 @@ def setup_restful_service(app):
     # Object endpoints
     api.add_resource(ObjectListResource, '/object')
     spec.path(resource=ObjectListResource, api=api)
-    api.add_resource(ObjectResource, '/object/<string:identifier>')
+    api.add_resource(ObjectResource, '/object/<hash64:identifier>')
     spec.path(resource=ObjectResource, api=api)
     api.add_resource(CommentDeleteResource,
                      '/<any(file, config, blob, object):type>/<hash64:identifier>/comment/<int:comment_id>',
@@ -168,7 +168,7 @@ def setup_restful_service(app):
     # File endpoints
     api.add_resource(FileListResource, '/file')
     spec.path(resource=FileListResource, api=api)
-    api.add_resource(FileResource, '/file/<string:identifier>')
+    api.add_resource(FileResource, '/file/<hash64:identifier>')
     spec.path(resource=FileResource, api=api)
 
     # Config endpoints

--- a/core/util.py
+++ b/core/util.py
@@ -121,4 +121,5 @@ def is_true(flag):
 
 
 class HashConverter(BaseConverter):
-    regex = '(root|[A-Fa-f0-9]{64})'
+    # MD5/SHA1/SHA256/SHA512 (32,40,64,128)
+    regex = '(root|[A-Fa-f0-9]{32,128})'

--- a/model/file.py
+++ b/model/file.py
@@ -37,6 +37,7 @@ class File(Object):
 
     @classmethod
     def get(cls, identifier):
+        identifier = identifier.lower()
         file = File.query.filter(File.dhash == identifier)
         if file.scalar():
             return file
@@ -44,9 +45,7 @@ class File(Object):
             File.sha1 == identifier,
             File.sha256 == identifier,
             File.sha512 == identifier,
-            File.md5 == identifier,
-            File.ssdeep == identifier,
-            File.humanhash == identifier))
+            File.md5 == identifier))
 
     @classmethod
     def get_or_create(cls, file, parent=None, metakeys=None, share_with=None):

--- a/model/object.py
+++ b/model/object.py
@@ -217,7 +217,7 @@ class Object(db.Model):
         Don't include internal (sequential) identifiers in filtering!
         Used by Object.access
         """
-        return cls.query.filter(cls.dhash == identifier)
+        return cls.query.filter(cls.dhash == identifier.lower())
 
     @classmethod
     def _get_or_create(cls, obj, parent=None, metakeys=None, share_with=None):

--- a/resources/comment.py
+++ b/resources/comment.py
@@ -8,7 +8,7 @@ from core.capabilities import Capabilities
 
 from schema.comment import CommentRequestSchema, CommentItemResponseSchema
 
-from . import logger, requires_capabilities, requires_authorization
+from . import logger, requires_capabilities, requires_authorization, access_object
 
 
 class CommentResource(Resource):
@@ -28,7 +28,7 @@ class CommentResource(Resource):
               schema:
                 type: string
                 enum: [file, config, blob, object]
-              description: Type of commented object (ignored)
+              description: Type of commented object
             - in: path
               name: identifier
               schema:
@@ -45,7 +45,7 @@ class CommentResource(Resource):
             404:
                 description: When object doesn't exist or user doesn't have access to this object.
         """
-        db_object = Object.access(identifier)
+        db_object = access_object(type, identifier)
         if not db_object:
             raise NotFound("Object not found")
 
@@ -72,7 +72,7 @@ class CommentResource(Resource):
               schema:
                 type: string
                 enum: [file, config, blob, object]
-              description: Type of commented object (ignored)
+              description: Type of commented object
             - in: path
               name: identifier
               schema:
@@ -102,7 +102,7 @@ class CommentResource(Resource):
         if obj.errors:
             return {"errors": obj.errors}, 400
 
-        db_object = Object.access(identifier)
+        db_object = access_object(type, identifier)
         if db_object is None:
             raise NotFound("Object not found")
 
@@ -161,7 +161,7 @@ class CommentDeleteResource(Resource):
             404:
                 description: When object doesn't exist or user doesn't have access to this object.
         """
-        db_object = Object.access(identifier)
+        db_object = access_object(type, identifier)
         if db_object is None:
             raise NotFound("Object not found")
 

--- a/resources/relations.py
+++ b/resources/relations.py
@@ -1,9 +1,9 @@
 from flask_restful import Resource
+from werkzeug.exceptions import NotFound
 
-from model import Object
 from core.schema import RelationsSchema
 
-from . import deprecated, authenticated_access, requires_authorization
+from . import access_object, deprecated, requires_authorization
 
 
 class RelationsResource(Resource):
@@ -42,7 +42,9 @@ class RelationsResource(Resource):
             404:
                 description: When object doesn't exist or user doesn't have access to this object.
         """
-        db_object = authenticated_access(Object, identifier)
+        db_object = access_object(type, identifier)
+        if db_object is None:
+            raise NotFound("Object not found")
 
         relations = RelationsSchema()
         dumped_relations = relations.dump(db_object)

--- a/resources/search.py
+++ b/resources/search.py
@@ -3,7 +3,7 @@ from flask_restful import Resource
 from luqum.parser import ParseError
 from werkzeug.exceptions import BadRequest
 
-from model import db, Object
+from model import Object
 from core.schema import SearchSchema, ObjectBase
 from core.search import SQLQueryBuilderBaseException, SQLQueryBuilder
 

--- a/resources/share.py
+++ b/resources/share.py
@@ -78,7 +78,7 @@ class ShareResource(Resource):
               schema:
                 type: string
                 enum: [file, config, blob, object]
-              description: Type of object (ignored)
+              description: Type of object
             - in: path
               name: identifier
               schema:

--- a/tests/frontend/cypress/integration/sample.js
+++ b/tests/frontend/cypress/integration/sample.js
@@ -51,6 +51,10 @@ describe("Sample view test - Malwarecage", function () {
       cy.contains(fileData.sha256);
 
       cy.visit("/sample/fake");
+      cy.contains(
+        "The requested URL was not found on the server. If you entered the URL manually please check your spelling and try again."
+      );
+      cy.visit("/sample/03040506708090aabbccddeeff112233");
       cy.contains("Object not found");
 
       cy.contains("Logout").click();


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
- `type` argument in generic object-related endpoint is not respected. It makes a significant difference because in current version:
    - `/file/<md5>/tag` doesn't work (md5 is defined only for files)
    - `/file/<sha256>/tag` should return 404 if <sha256> identifier relates to another type of object (e.g. config)
- Identifier is case-sensitive in some endpoints and case-insensitive in the others.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
- `type` is respected by all endpoints.
- Removed `authenticated_access`, `NotFound` exception should be thrown by resource code with appropriate message instead of generic `"Object not found"`
- object access by id treats `identifier` as case-insensitive value
- ssdeep and humanhash are no longer accepted by `File.get` (they doesn't match `<hash64:identifier>` anyway, it never worked)
