### PR TITLE
Revisited tag endpoints

### DIFF
--- a/core/service.py
+++ b/core/service.py
@@ -36,6 +36,8 @@ from resources.user import (
     UserGetPasswordChangeTokenResource
 )
 
+from schema.tag import TagItemResponseSchema
+
 from . import log
 from .apispec_utils import ApispecFlaskRestful
 
@@ -228,4 +230,7 @@ def setup_restful_service(app):
     spec.path(resource=GroupResource, api=api)
     api.add_resource(GroupMemberResource, '/group/<name>/member/<login>')
     spec.path(resource=GroupMemberResource, api=api)
+
+    # Additional schemas
+    spec.components.schema("TagItemResponse", schema=TagItemResponseSchema)
     return api, spec

--- a/resources/tag.py
+++ b/resources/tag.py
@@ -149,7 +149,7 @@ class TagResource(Resource):
                       items:
                         $ref: '#/components/schemas/TagItemResponse'
             400:
-                description: When tag isn't valid
+                description: When tag is invalid
             403:
                 description: When user doesn't have `adding_tags` capability.
             404:
@@ -217,7 +217,7 @@ class TagResource(Resource):
                       items:
                         $ref: '#/components/schemas/TagItemResponse'
             400:
-                description: When tag isn't valid
+                description: When tag is invalid
             403:
                 description: When user doesn't have `removing_tags` capability.
             404:

--- a/resources/tag.py
+++ b/resources/tag.py
@@ -3,9 +3,10 @@ from flask_restful import Resource
 from sqlalchemy.sql import and_
 from werkzeug.exceptions import NotFound
 
-from model import db, Object, Tag, object_tag_table, ObjectPermission
+from model import db, Tag, object_tag_table, ObjectPermission
 from core.capabilities import Capabilities
-from core.schema import TagSchema
+
+from schema.tag import TagListRequestSchema, TagRequestSchema, TagItemResponseSchema
 
 from . import access_object, logger, requires_capabilities, requires_authorization
 
@@ -39,24 +40,29 @@ class TagListResource(Resource):
                     schema:
                       type: array
                       items:
-                        $ref: '#/components/schemas/Tag'
+                        $ref: '#/components/schemas/TagItemResponse'
         """
-        tag_prefix = request.args.get('query')
+        schema = TagListRequestSchema()
+        obj = schema.load(request.args)
+        if obj.errors:
+            return {"errors": obj.errors}, 400
 
-        if not tag_prefix or len(tag_prefix) == 0:
-            tags = []
-        else:
-            tag_prefix = tag_prefix.lower()
-            tags = db.session.query(Tag.tag)\
-                             .distinct(Tag.tag)\
-                             .join(object_tag_table, object_tag_table.c.tag_id == Tag.id) \
-                             .join(ObjectPermission,
-                                   and_(ObjectPermission.object_id == object_tag_table.c.object_id,
-                                        g.auth_user.is_member(ObjectPermission.group_id))) \
-                             .filter(Tag.tag.like(tag_prefix + "%")).all()
-        multi_tag = TagSchema(many=True)
-        dumped_tags = multi_tag.dump(tags)
-        return dumped_tags
+        tags = (
+            db.session.query(Tag.tag)
+                      .distinct(Tag.tag)
+                      .join(object_tag_table, object_tag_table.c.tag_id == Tag.id)
+                      .join(ObjectPermission,
+                            and_(ObjectPermission.object_id == object_tag_table.c.object_id,
+                                 g.auth_user.is_member(ObjectPermission.group_id)))
+        )
+        tag_prefix = obj.data["query"]
+
+        if tag_prefix:
+            tags = tags.filter(Tag.tag.startswith(tag_prefix, autoescape=True))
+        tags = tags.all()
+
+        schema = TagItemResponseSchema(many=True)
+        return schema.dump(tags)
 
 
 class TagResource(Resource):
@@ -91,7 +97,7 @@ class TagResource(Resource):
                     schema:
                       type: array
                       items:
-                        $ref: '#/components/schemas/Tag'
+                        $ref: '#/components/schemas/TagItemResponse'
             404:
                 description: When object doesn't exist or user doesn't have access to this object.
         """
@@ -99,12 +105,8 @@ class TagResource(Resource):
         if db_object is None:
             raise NotFound("Object not found")
 
-        tags = db.session.query(Tag) \
-            .filter(Tag.objects.any(id=db_object.id)).all()
-
-        multi_tag = TagSchema(many=True)
-        dumped_tags = multi_tag.dump(tags)
-        return dumped_tags
+        schema = TagItemResponseSchema(many=True)
+        return schema.dump(db_object.tags)
 
     @requires_authorization
     @requires_capabilities(Capabilities.adding_tags)
@@ -132,31 +134,46 @@ class TagResource(Resource):
               schema:
                 type: string
               description: Object identifier
+        requestBody:
+            description: Tag value
+            content:
+              application/json:
+                schema: TagRequestSchema
         responses:
             200:
                 description: When tag is successfully added
+                content:
+                  application/json:
+                    schema:
+                      type: array
+                      items:
+                        $ref: '#/components/schemas/TagItemResponse'
             400:
-                description: When tag or request body isn't valid
+                description: When tag isn't valid
             403:
                 description: When user doesn't have `adding_tags` capability.
             404:
                 description: When object doesn't exist or user doesn't have access to this object.
         """
-        schema = TagSchema()
+        schema = TagRequestSchema()
         obj = schema.loads(request.get_data(as_text=True))
-
         if obj.errors:
             return {"errors": obj.errors}, 400
 
         db_object = access_object(type, identifier)
         if db_object is None:
             raise NotFound("Object not found")
-        tag_name = obj.data["tag"].lower().strip()
+        tag_name = obj.data["tag"]
 
-        was_modified = db_object.add_tag(tag_name)
+        db_object.add_tag(tag_name)
 
-        logger.info('tag added', extra={'tag_name': tag_name, 'dhash': db_object.dhash})
-        return {"modified": was_modified}, 200
+        logger.info('Tag added', extra={
+            'tag': tag_name,
+            'dhash': db_object.dhash
+        })
+        db.session.refresh(db_object)
+        schema = TagItemResponseSchema(many=True)
+        return schema.dump(db_object.tags)
 
     @requires_authorization
     @requires_capabilities(Capabilities.removing_tags)
@@ -184,29 +201,45 @@ class TagResource(Resource):
               schema:
                 type: string
               description: Object identifier
+            - in: query
+              name: tag
+              schema:
+                type: string
+              description: Tag to be deleted
+              required: true
         responses:
             200:
                 description: When tag is successfully removed
+                content:
+                  application/json:
+                    schema:
+                      type: array
+                      items:
+                        $ref: '#/components/schemas/TagItemResponse'
             400:
-                description: When tag or request body isn't valid
+                description: When tag isn't valid
             403:
                 description: When user doesn't have `removing_tags` capability.
             404:
                 description: When object doesn't exist or user doesn't have access to this object.
         """
 
-        schema = TagSchema()
-        obj = schema.load({"tag": request.args.get("tag")})
-
+        schema = TagRequestSchema()
+        obj = schema.load(request.args)
         if obj.errors:
             return {"errors": obj.errors}, 400
 
         db_object = access_object(type, identifier)
         if db_object is None:
             raise NotFound("Object not found")
-        tag_name = obj.data["tag"].lower().strip()
 
-        was_modified = db_object.remove_tag(tag_name)
+        tag_name = obj.data["tag"]
+        db_object.remove_tag(tag_name)
 
-        logger.info('tag removed', extra={'tag_name': tag_name, 'dhash': db_object.dhash})
-        return {"modified": was_modified}, 200
+        logger.info('Tag removed', extra={
+            'tag': tag_name,
+            'dhash': db_object.dhash
+        })
+        db.session.refresh(db_object)
+        schema = TagItemResponseSchema(many=True)
+        return schema.dump(db_object.tags)

--- a/resources/tag.py
+++ b/resources/tag.py
@@ -55,8 +55,8 @@ class TagListResource(Resource):
                             and_(ObjectPermission.object_id == object_tag_table.c.object_id,
                                  g.auth_user.is_member(ObjectPermission.group_id)))
         )
-        tag_prefix = obj.data["query"]
 
+        tag_prefix = obj.data["query"]
         if tag_prefix:
             tags = tags.filter(Tag.tag.startswith(tag_prefix, autoescape=True))
         tags = tags.all()
@@ -163,8 +163,8 @@ class TagResource(Resource):
         db_object = access_object(type, identifier)
         if db_object is None:
             raise NotFound("Object not found")
-        tag_name = obj.data["tag"]
 
+        tag_name = obj.data["tag"]
         db_object.add_tag(tag_name)
 
         logger.info('Tag added', extra={

--- a/schema/tag.py
+++ b/schema/tag.py
@@ -1,0 +1,29 @@
+from marshmallow import Schema, fields, validates, ValidationError, pre_load
+
+
+class TagSchemaBase(Schema):
+    tag = fields.Str(required=True, allow_none=False)
+
+    @pre_load
+    def sanitize_tag(self, params):
+        params = dict(params)
+        if params.get("tag"):
+            params["tag"] = params["tag"].lower().strip()
+        return params
+
+    @validates("tag")
+    def validate_tag(self, value):
+        if not value:
+            raise ValidationError("Tag shouldn't be empty")
+
+
+class TagListRequestSchema(Schema):
+    query = fields.Str(missing="")
+
+
+class TagRequestSchema(TagSchemaBase):
+    pass
+
+
+class TagItemResponseSchema(TagSchemaBase):
+    pass


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
- `PUT/DELETE /{type}/{identifier}/tag` documentation was invalid
- `PUT/DELETE /{type}/{identifier}/tag` returns useless `{"modified": true/false}` response
- `GET /tag` returns empty list when no query is provided - this behavior is counterintuitive
- `GET /tag` doesn't properly escape '%' and '_' wildcards which are directly provided to LIKE query
- `GET /{type}/{identifier}/tag` uses two SQL queries for providing object tags - they're already joined during `Object.access`

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
- **Breaking change**: `PUT/DELETE /{type}/{identifier}/tag` returns updated list of tags instead of laconic `{modified:...}`. I think nobody relies on that response, it's not used by mwdblib nor web.
- Provided tags are validated on Schema level
- `GET /tag` returns all accessible tags when empty query is provided 
- `GET /tag` uses `.startswith` with proper escaping
- `GET /{type}/{identifier}/tag` is optimized

**Test plan**
<!-- Explain how to test your changes -->
- Checked all endpoints in Swagger (http://127.0.0.1/docs)
- Checked all related web functionalities:
   - add tag
   - remove tag
   - check tag autocompletion
