### PR TITLE
Revisited relations endpoints

### DIFF
--- a/core/service.py
+++ b/core/service.py
@@ -25,8 +25,8 @@ from resources.metakey import (
     MetakeyDefinitionManageResource, MetakeyListDefinitionManageResource,
     MetakeyPermissionResource
 )
-from resources.object import ObjectResource, ObjectListResource, ObjectChildResource
-from resources.relations import RelationsResource
+from resources.object import ObjectResource, ObjectListResource
+from resources.relations import RelationsResource, ObjectChildResource
 from resources.server import PingResource, ServerInfoResource
 from resources.search import SearchResource
 from resources.share import ShareGroupListResource, ShareResource

--- a/resources/object.py
+++ b/resources/object.py
@@ -251,7 +251,7 @@ class ObjectChildResource(Resource):
         security:
             - bearerAuth: []
         tags:
-            - object
+            - relations
         parameters:
             - in: path
               name: type

--- a/resources/object.py
+++ b/resources/object.py
@@ -15,7 +15,7 @@ from schema.object import (
     ObjectItemResponseSchema
 )
 
-from . import logger, requires_authorization, requires_capabilities, access_object
+from . import logger, requires_authorization
 
 
 class ObjectListResource(Resource):
@@ -235,62 +235,3 @@ class ObjectResource(Resource):
     @requires_authorization
     def put(self, identifier):
         return self.post(identifier)
-
-
-class ObjectChildResource(Resource):
-    @requires_authorization
-    @requires_capabilities(Capabilities.adding_parents)
-    def put(self, type, parent, child):
-        """
-        ---
-        summary: Link existing objects
-        description: |
-            Add new relation between existing objects.
-
-            Requires `adding_parents` capability.
-        security:
-            - bearerAuth: []
-        tags:
-            - relations
-        parameters:
-            - in: path
-              name: type
-              schema:
-                type: string
-                enum: [file, config, blob, object]
-              description: Type of parent object
-            - in: path
-              name: parent
-              description: Identifier of the parent object
-              required: true
-              schema:
-                type: string
-            - in: path
-              name: child
-              description: Identifier of the child object
-              required: true
-              schema:
-                type: string
-        responses:
-            200:
-                description: When relation was successfully added
-            403:
-                description: When user doesn't have `adding_parents` capability.
-            404:
-                description: When one of objects doesn't exist or user doesn't have access to object.
-        """
-        parent_object = access_object(type, parent)
-        if parent_object is None:
-            raise NotFound("Parent object not found")
-
-        child_object = Object.access(child)
-        if child_object is None:
-            raise NotFound("Child object not found")
-
-        child_object.add_parent(parent_object, commit=False)
-
-        db.session.commit()
-        logger.info('child added', extra={
-            'parent': parent_object.dhash,
-            'child': child_object.dhash
-        })

--- a/resources/relations.py
+++ b/resources/relations.py
@@ -1,9 +1,11 @@
 from flask_restful import Resource
 from werkzeug.exceptions import NotFound
 
+from model import db, Object
+from core.capabilities import Capabilities
 from schema.relations import RelationsResponseSchema
 
-from . import access_object, requires_authorization
+from . import logger, requires_authorization, requires_capabilities, access_object
 
 
 class RelationsResource(Resource):
@@ -47,3 +49,62 @@ class RelationsResource(Resource):
 
         relations = RelationsResponseSchema()
         return relations.dump(db_object)
+
+
+class ObjectChildResource(Resource):
+    @requires_authorization
+    @requires_capabilities(Capabilities.adding_parents)
+    def put(self, type, parent, child):
+        """
+        ---
+        summary: Link existing objects
+        description: |
+            Add new relation between existing objects.
+
+            Requires `adding_parents` capability.
+        security:
+            - bearerAuth: []
+        tags:
+            - relations
+        parameters:
+            - in: path
+              name: type
+              schema:
+                type: string
+                enum: [file, config, blob, object]
+              description: Type of parent object
+            - in: path
+              name: parent
+              description: Identifier of the parent object
+              required: true
+              schema:
+                type: string
+            - in: path
+              name: child
+              description: Identifier of the child object
+              required: true
+              schema:
+                type: string
+        responses:
+            200:
+                description: When relation was successfully added
+            403:
+                description: When user doesn't have `adding_parents` capability.
+            404:
+                description: When one of objects doesn't exist or user doesn't have access to object.
+        """
+        parent_object = access_object(type, parent)
+        if parent_object is None:
+            raise NotFound("Parent object not found")
+
+        child_object = Object.access(child)
+        if child_object is None:
+            raise NotFound("Child object not found")
+
+        child_object.add_parent(parent_object, commit=False)
+
+        db.session.commit()
+        logger.info('Child added', extra={
+            'parent': parent_object.dhash,
+            'child': child_object.dhash
+        })

--- a/resources/relations.py
+++ b/resources/relations.py
@@ -1,26 +1,25 @@
 from flask_restful import Resource
 from werkzeug.exceptions import NotFound
 
-from core.schema import RelationsSchema
+from schema.relations import RelationsResponseSchema
 
-from . import access_object, deprecated, requires_authorization
+from . import access_object, requires_authorization
 
 
 class RelationsResource(Resource):
-    @deprecated
     @requires_authorization
     def get(self, type, identifier):
         """
         ---
-        summary: Get object relations (deprecated)
+        summary: Get object relations
         description: |
             Returns relations attached to an object.
 
-            Deprecated: relations are already available via simple object get.
+            Note: relations are already available via simple object get.
         security:
             - bearerAuth: []
         tags:
-            - deprecated
+            - relations
         parameters:
             - in: path
               name: type
@@ -38,7 +37,7 @@ class RelationsResource(Resource):
                 description: Relations object
                 content:
                   application/json:
-                    schema: RelationsSchema
+                    schema: RelationsResponseSchema
             404:
                 description: When object doesn't exist or user doesn't have access to this object.
         """
@@ -46,6 +45,5 @@ class RelationsResource(Resource):
         if db_object is None:
             raise NotFound("Object not found")
 
-        relations = RelationsSchema()
-        dumped_relations = relations.dump(db_object)
-        return dumped_relations
+        relations = RelationsResponseSchema()
+        return relations.dump(db_object)

--- a/schema/relations.py
+++ b/schema/relations.py
@@ -1,0 +1,7 @@
+from marshmallow import Schema, fields
+from schema.object import ObjectListItemResponseSchema
+
+
+class RelationsResponseSchema(Schema):
+    parents = fields.Nested(ObjectListItemResponseSchema, many=True, required=True, allow_none=False)
+    children = fields.Nested(ObjectListItemResponseSchema, many=True, required=True, allow_none=False)


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [x] I've updated documentation to reflect my change (if applicable)

**What changed?**
<!-- Explain how the code works currently -->
- Refactored RelationsResource schema to follow the convention
- Rollbacked deprecation of `GET ​/{type}​/{identifier}​/relations`. It's not completely bad, it's just misused.
- Moved `PUT /{type}/{parent}/child/{child}` (ObjectChildResource) to `relations` group.

**Test plan**
<!-- Explain how to test your changes -->
- Checked if `GET ​/{type}​/{identifier}​/relations` and `PUT /{type}/{parent}/child/{child}` still works
