### PR TITLE
Allow to use 'uploader:' query for groups

### DIFF
--- a/core/search/fields.py
+++ b/core/search/fields.py
@@ -6,7 +6,7 @@ from typing import List, Union, Type, Any
 from flask import g
 
 from luqum.tree import Range, Term
-from sqlalchemy import and_
+from sqlalchemy import and_, or_
 
 from model import db, Object, Metakey, MetakeyDefinition, Group, ObjectPermission, User
 from model.object import AccessType
@@ -223,7 +223,7 @@ class UploaderField(BaseField):
                                   .join(User.groups)
                                   .filter(g.auth_user.is_member(Group.id))
                                   .filter(Group.name != "public")
-                                  .filter(Group.name == value)).all()
+                                  .filter(or_(Group.name == value, User.login == value))).all()
 
         uploader_ids = [u.id for u in uploader]
         return self.column.any(


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x]  I've tested my changes by building and running the project, and testing changed functionality (if applicable)

**What is the current behaviour?**
Allow to search only for uploader: user

**What is the new behaviour?**
Allow to search for uploader: user or group

**Closing issues**

closes #94 
