### PR TITLE
Explicitly-defined Object.children relationship

### DIFF
--- a/model/object.py
+++ b/model/object.py
@@ -127,7 +127,15 @@ class Object(db.Model):
         primaryjoin=(id == relation.c.child_id),
         secondaryjoin=(id == relation.c.parent_id),
         order_by=relation.c.creation_time.desc(),
-        backref=db.backref('children', order_by=relation.c.creation_time.desc()))
+        back_populates="children"
+    )
+    children = db.relationship(
+        "Object", secondary=relation,
+        primaryjoin=(id == relation.c.parent_id),
+        secondaryjoin=(id == relation.c.child_id),
+        order_by=relation.c.creation_time.desc(),
+        back_populates="parents"
+    )
 
     meta = db.relationship('Metakey', backref='object', lazy=True)
     comments = db.relationship('Comment', backref='object', lazy='dynamic')


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
- `Object.children` relationship is added by backref, so it is available on instance-level, but we can't refer to that relationship on class-level.
- Required by #34 

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
- `Object.children` is defined as separate relationship, connected with `Object.parents` with `back_populates`.

Ref: https://docs.sqlalchemy.org/en/13/orm/join_conditions.html#self-referential-many-to-many-relationship

SQLAlchemy documentation proposes backref as a first choice but I don't see anything against back_populates.

**Test plan**
<!-- Explain how to test your changes -->
- Possible major problems caused by this change should be found by automated tests
- Check if existing relations are correct
- Check related features: upload with parent and adding link between objects

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->
