### PR TITLE
Fix ISE 500 in 'parent:' query while querying for File and ListField

### DIFF
--- a/core/search/search.py
+++ b/core/search/search.py
@@ -148,7 +148,7 @@ class SQLQueryBuilder(LuceneTreeVisitorV2):
             inner_context = SQLQueryBuilderContext()
             condition = self.visit(node.expr, parents + [node], inner_context)
             # Make aliased entity for inner query
-            relative = aliased(inner_context.queried_type)
+            relative = aliased(inner_context.queried_type, flat=True)
             subquery = (
                 db.session.query(relative.id)
                           .select_entity_from(relative)  # Use aliased entity in subquery


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

- `parent:(file.size:5000 AND tag:costam)` throws ISE 500 with unhandled SQL exception "Error: column anon_2.object_id does not exist at character 2033"
- It seems that current version of search can't properly handle ListField and specialized field in the same subquery.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
- `parent:(file.size:5000 AND tag:costam)` works as expected
