### PR TITLE
Feature/dont show the plugins table in about when no plugins available

### DIFF
--- a/malwarecage/web/src/components/About.js
+++ b/malwarecage/web/src/components/About.js
@@ -65,7 +65,7 @@ class About extends Component {
                         </table>
                     </div>
                 :
-                    <p>No plugins are installed. Visit our <a href="https://github.com/CERT-Polska/malwarecage/wiki">documentation</a> to learn about Malwarecgae plugins and how they can be used and installed.</p>
+                    <p style={{textAlign: "center"}}>No plugins are installed. Visit our <a href="https://github.com/CERT-Polska/malwarecage/wiki">documentation</a> to learn about Malwarecage plugins and how they can be used and installed.</p>
                 }
             </div>
         );

--- a/malwarecage/web/src/components/About.js
+++ b/malwarecage/web/src/components/About.js
@@ -54,7 +54,7 @@ class About extends Component {
                         <table className="table table-striped table-bordered wrap-table" >
                             <thead>
                                 <tr>
-                                    <th>Pluginname</th>
+                                    <th>Plugin name</th>
                                     <th>Description</th>
                                     <th>Version</th>
                                 </tr>
@@ -65,7 +65,7 @@ class About extends Component {
                         </table>
                     </div>
                 :
-                    <p>No plugins are installed. Visit our <a href="https://hackmd.io/rcdkXnEISPiPAnwo8INbGw#Integration-guide">documentation</a> to learn about Malwarecgae plugins and how they can be used and installed.</p>
+                    <p>No plugins are installed. Visit our <a href="https://github.com/CERT-Polska/malwarecage/wiki">documentation</a> to learn about Malwarecgae plugins and how they can be used and installed.</p>
                 }
             </div>
         );

--- a/malwarecage/web/src/components/About.js
+++ b/malwarecage/web/src/components/About.js
@@ -42,7 +42,7 @@ const PluginsTable = (props) => {
     }
     else{
         return (
-            <p>No plugins are installed. Visit our <a href="https://github.com/CERT-Polska/malwarecage/tree/master/plugins">documentation</a> to learn about Malwarecgae plugins and how they can be used and installed.</p>
+            <p>No plugins are installed. Visit our <a href="https://hackmd.io/rcdkXnEISPiPAnwo8INbGw#Integration-guide">documentation</a> to learn about Malwarecgae plugins and how they can be used and installed.</p>
         )
     }
 }

--- a/malwarecage/web/src/components/About.js
+++ b/malwarecage/web/src/components/About.js
@@ -21,6 +21,31 @@ const PluginItems = (props) => {
     )
 }
 
+const PluginsTable = (props) => {
+    if (props.plugins.length) {
+        return (
+            <div className="container">
+                <table className="table table-striped table-bordered wrap-table" >
+                    <thead>
+                        <tr>
+                            <th>Pluginname</th>
+                            <th>Description</th>
+                            <th>Version</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {props.plugins}
+                    </tbody>
+                </table>
+            </div>
+        )
+    }
+    else{
+        return (
+            <p>No plugins are installed. Visit our <a href="https://github.com/CERT-Polska/malwarecage/tree/master/plugins">documentation</a> to learn about Malwarecgae plugins and how they can be used and installed.</p>
+        )
+    }
+}
 
 class About extends Component {
     render() {
@@ -30,7 +55,7 @@ class About extends Component {
                 info = {value}
             />
         ));
-        
+
         return (
             <div className="align-items-center">
                 <div className="jumbotron d-flex align-items-center" style={{backgroundColor: "#101c28", color: "white"}}>
@@ -50,20 +75,7 @@ class About extends Component {
                         </div>
                     </View>
                 </div>
-                <div className="container">
-                    <table className="table table-striped table-bordered wrap-table">
-                        <thead>
-                            <tr>
-                                <th>Plugin name</th>
-                                <th>Description</th>
-                                <th>Version</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {plugins}
-                        </tbody>
-                    </table>
-                </div>
+                <PluginsTable plugins={plugins} />
             </div>
         );
     }

--- a/malwarecage/web/src/components/About.js
+++ b/malwarecage/web/src/components/About.js
@@ -21,32 +21,6 @@ const PluginItems = (props) => {
     )
 }
 
-const PluginsTable = (props) => {
-    if (props.plugins.length) {
-        return (
-            <div className="container">
-                <table className="table table-striped table-bordered wrap-table" >
-                    <thead>
-                        <tr>
-                            <th>Pluginname</th>
-                            <th>Description</th>
-                            <th>Version</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {props.plugins}
-                    </tbody>
-                </table>
-            </div>
-        )
-    }
-    else{
-        return (
-            <p>No plugins are installed. Visit our <a href="https://hackmd.io/rcdkXnEISPiPAnwo8INbGw#Integration-guide">documentation</a> to learn about Malwarecgae plugins and how they can be used and installed.</p>
-        )
-    }
-}
-
 class About extends Component {
     render() {
         let plugins = Object.entries(this.props.config["active_plugins"]).sort().map(([key, value]) => (
@@ -75,7 +49,24 @@ class About extends Component {
                         </div>
                     </View>
                 </div>
-                <PluginsTable plugins={plugins} />
+                {plugins.length ?
+                    <div className="container">
+                        <table className="table table-striped table-bordered wrap-table" >
+                            <thead>
+                                <tr>
+                                    <th>Pluginname</th>
+                                    <th>Description</th>
+                                    <th>Version</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {plugins}
+                            </tbody>
+                        </table>
+                    </div>
+                :
+                    <p>No plugins are installed. Visit our <a href="https://hackmd.io/rcdkXnEISPiPAnwo8INbGw#Integration-guide">documentation</a> to learn about Malwarecgae plugins and how they can be used and installed.</p>
+                }
             </div>
         );
     }


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
Empty table without any plugins is displayed when entering About section.

**What is the new behaviour?**
Information about no available plug-ins is displayed when entering About section.

**Test plan**
Enter About section when there are no plug-ins available. 

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->

closes #77
