### PR TITLE
Remove isAdmin artifact from code

### DIFF
--- a/malwarecage/web/src/components/ShowConfig.js
+++ b/malwarecage/web/src/components/ShowConfig.js
@@ -188,7 +188,6 @@ function mapStateToProps(state, ownProps)
 {
     return {
         ...ownProps,
-        isAdmin: state.auth.loggedUser.capabilities.includes("manage_users"),
         canDeleteObject: state.auth.loggedUser.capabilities.includes("removing_objects"),
     }
 }

--- a/malwarecage/web/src/components/ShowTextBlob.js
+++ b/malwarecage/web/src/components/ShowTextBlob.js
@@ -101,7 +101,6 @@ function mapStateToProps(state, ownProps)
 {
     return {
         ...ownProps,
-        isAdmin: state.auth.loggedUser.capabilities.includes("manage_users"),
         canDeleteObject: state.auth.loggedUser.capabilities.includes("removing_objects"),
     }
 }


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)

**What is the current behaviour?**
Unnecessary isAdmin prop from ShowConfig.js ShowTextBlob.js

**What is the new behaviour?**
Delete artifact in code