### PR TITLE
Regression fix: Config/Blob view tabs doesn't work

### DIFF
--- a/malwarecage/web/src/components/ShowConfig.js
+++ b/malwarecage/web/src/components/ShowConfig.js
@@ -189,6 +189,7 @@ function mapStateToProps(state, ownProps)
     return {
         ...ownProps,
         canDeleteObject: state.auth.loggedUser.capabilities.includes("removing_objects"),
+        router: state.router
     }
 }
 

--- a/malwarecage/web/src/components/ShowTextBlob.js
+++ b/malwarecage/web/src/components/ShowTextBlob.js
@@ -102,6 +102,7 @@ function mapStateToProps(state, ownProps)
     return {
         ...ownProps,
         canDeleteObject: state.auth.loggedUser.capabilities.includes("removing_objects"),
+        router: state.router
     }
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)

**What was fixed?**
<!-- Explain how the code works currently -->
- Tab switching in Config view (and possibly Blob view) doesn't work
- We're using `connected-react-router` so all connected components need to have injected router state to work properly with React History.
