### PR TITLE
Fixed 'copy to clipboard' hover behavior

### DIFF
--- a/malwarecage/web/src/components/Attributes.js
+++ b/malwarecage/web/src/components/Attributes.js
@@ -39,7 +39,7 @@ class DefaultAttributeRenderer extends Component {
                     }&nbsp;
                     {this.props.label}
                 </th>
-                <td className="copyable">
+                <td className="flickerable">
                     { visibleValues.map(attr => (
                         <div key={attr.value}>
                             {

--- a/malwarecage/web/src/components/Attributes.js
+++ b/malwarecage/web/src/components/Attributes.js
@@ -39,7 +39,7 @@ class DefaultAttributeRenderer extends Component {
                     }&nbsp;
                     {this.props.label}
                 </th>
-                <td>
+                <td className="copyable">
                     { visibleValues.map(attr => (
                         <div key={attr.value}>
                             {

--- a/malwarecage/web/src/components/Relations.js
+++ b/malwarecage/web/src/components/Relations.js
@@ -36,7 +36,7 @@ class RelationsBox extends Component {
     render() {
         const parents = (this.props.parents || [])
             .map((parent, index, array) =>
-                <tr key={`parent-${parent.id}`} className="copyable">
+                <tr key={`parent-${parent.id}`} className="flickerable">
                     <th>parent</th>
                     <td>
                         <span>
@@ -55,7 +55,7 @@ class RelationsBox extends Component {
 
         const children = (this.props.children || [])
             .map((child, index, array) =>
-                <tr key={`child-${child.id}`} className="copyable">
+                <tr key={`child-${child.id}`} className="flickerable">
                     <th>child</th>
                     <td>
                         <span>

--- a/malwarecage/web/src/components/Relations.js
+++ b/malwarecage/web/src/components/Relations.js
@@ -36,7 +36,7 @@ class RelationsBox extends Component {
     render() {
         const parents = (this.props.parents || [])
             .map((parent, index, array) =>
-                <tr key={`parent-${parent.id}`}>
+                <tr key={`parent-${parent.id}`} className="copyable">
                     <th>parent</th>
                     <td>
                         <span>
@@ -55,7 +55,7 @@ class RelationsBox extends Component {
 
         const children = (this.props.children || [])
             .map((child, index, array) =>
-                <tr key={`child-${child.id}`}>
+                <tr key={`child-${child.id}`} className="copyable">
                     <th>child</th>
                     <td>
                         <span>

--- a/malwarecage/web/src/components/ShowConfig.js
+++ b/malwarecage/web/src/components/ShowConfig.js
@@ -83,7 +83,7 @@ class ConfigRow extends Component {
 
         return (
             <React.Fragment>
-                <tr className="copyable">
+                <tr className="flickerable">
                     <th style={{cursor: 'pointer'}} onClick={this._toggle.bind(this)}>
                         <FontAwesomeIcon icon={this.state.open ? "minus" : "plus"} size="sm"/>&nbsp;
                         {this.state.name}

--- a/malwarecage/web/src/components/ShowConfig.js
+++ b/malwarecage/web/src/components/ShowConfig.js
@@ -83,7 +83,7 @@ class ConfigRow extends Component {
 
         return (
             <React.Fragment>
-                <tr>
+                <tr className="copyable">
                     <th style={{cursor: 'pointer'}} onClick={this._toggle.bind(this)}>
                         <FontAwesomeIcon icon={this.state.open ? "minus" : "plus"} size="sm"/>&nbsp;
                         {this.state.name}

--- a/malwarecage/web/src/components/ShowObject.js
+++ b/malwarecage/web/src/components/ShowObject.js
@@ -10,7 +10,7 @@ export default class ShowObject extends Component {
     render() {
         let ObjectPresenter = this.props.objectPresenterComponent;
         return (
-            <div className="card-body flicker-element">
+            <div className="card-body">
                 <Extendable ident="showObject" object={this.props.object}>
                     <div className="row">
                         <div className="col-md-7">

--- a/malwarecage/web/src/components/ShowSample.js
+++ b/malwarecage/web/src/components/ShowSample.js
@@ -16,7 +16,7 @@ function SampleDetails(props) {
     return (
         <DataTable>
             <Extendable ident="showSampleDetails" object={props}>
-                <tr className="copyable">
+                <tr className="flickerable">
                     <th>Filename</th>
                     <td id="file_name">
                         <Link to={makeSearchLink("name", props.file_name, false, '')}>
@@ -27,7 +27,7 @@ function SampleDetails(props) {
                         </span>
                     </td>
                 </tr>
-                <tr className="copyable">
+                <tr className="flickerable">
                     <th>File size</th>
                     <td id="file_size">
                         <Link to={makeSearchLink("size", props.file_size, false, '')}>{props.file_size}</Link>
@@ -36,7 +36,7 @@ function SampleDetails(props) {
                         </span>
                     </td>
                 </tr>
-                <tr className="copyable">
+                <tr className="flickerable">
                     <th>File type</th>
                     <td id="file_type">
                         <Link to={makeSearchLink("type", props.file_type, false, '')}>{props.file_type}</Link>
@@ -45,7 +45,7 @@ function SampleDetails(props) {
                         </span>
                     </td>
                 </tr>
-                <tr className="copyable">
+                <tr className="flickerable">
                     <th>md5</th>
                     <td id="md5">
                         <Hash hash={props.md5}/>
@@ -54,7 +54,7 @@ function SampleDetails(props) {
                         </span>
                     </td>
                 </tr>
-                <tr className="copyable">
+                <tr className="flickerable">
                     <th>sha1</th>
                     <td id="sha1">
                         <Hash hash={props.sha1}/>
@@ -63,7 +63,7 @@ function SampleDetails(props) {
                         </span>
                     </td>
                 </tr>
-                <tr className="copyable">
+                <tr className="flickerable">
                     <th>sha256</th>
                     <td id="sha256">
                         <Hash hash={props.sha256}/>
@@ -72,7 +72,7 @@ function SampleDetails(props) {
                         </span>
                     </td>
                 </tr>
-                <tr className="copyable">
+                <tr className="flickerable">
                     <th>sha512</th>
                     <td id="sha512">
                         <Hash hash={props.sha512}/>
@@ -81,7 +81,7 @@ function SampleDetails(props) {
                         </span>
                     </td>
                 </tr>
-                <tr className="copyable">
+                <tr className="flickerable">
                     <th>crc32</th>
                     <td id="crc32" className="text-monospace">
                         {props.crc32}
@@ -90,7 +90,7 @@ function SampleDetails(props) {
                         </span>
                     </td>
                 </tr>
-                <tr className="copyable">
+                <tr className="flickerable">
                     <th>ssdeep</th>
                     <td id="ssdeep" className="text-monospace">
                         <Link to={makeSearchLink("ssdeep", props.ssdeep, false, '')}>{props.ssdeep}</Link>

--- a/malwarecage/web/src/components/ShowSample.js
+++ b/malwarecage/web/src/components/ShowSample.js
@@ -14,9 +14,9 @@ import ActionCopyToClipboard from "./ActionCopyToClipboard";
 
 function SampleDetails(props) {
     return (
-        <DataTable className="flicker-element">
-            <Extendable ident="showSampleDetails" object={props} className="flicker-element">
-                <tr>
+        <DataTable>
+            <Extendable ident="showSampleDetails" object={props}>
+                <tr className="copyable">
                     <th>Filename</th>
                     <td id="file_name">
                         <Link to={makeSearchLink("name", props.file_name, false, '')}>
@@ -27,7 +27,7 @@ function SampleDetails(props) {
                         </span>
                     </td>
                 </tr>
-                <tr>
+                <tr className="copyable">
                     <th>File size</th>
                     <td id="file_size">
                         <Link to={makeSearchLink("size", props.file_size, false, '')}>{props.file_size}</Link>
@@ -36,7 +36,7 @@ function SampleDetails(props) {
                         </span>
                     </td>
                 </tr>
-                <tr>
+                <tr className="copyable">
                     <th>File type</th>
                     <td id="file_type">
                         <Link to={makeSearchLink("type", props.file_type, false, '')}>{props.file_type}</Link>
@@ -45,7 +45,7 @@ function SampleDetails(props) {
                         </span>
                     </td>
                 </tr>
-                <tr>
+                <tr className="copyable">
                     <th>md5</th>
                     <td id="md5">
                         <Hash hash={props.md5}/>
@@ -54,7 +54,7 @@ function SampleDetails(props) {
                         </span>
                     </td>
                 </tr>
-                <tr>
+                <tr className="copyable">
                     <th>sha1</th>
                     <td id="sha1">
                         <Hash hash={props.sha1}/>
@@ -63,7 +63,7 @@ function SampleDetails(props) {
                         </span>
                     </td>
                 </tr>
-                <tr>
+                <tr className="copyable">
                     <th>sha256</th>
                     <td id="sha256">
                         <Hash hash={props.sha256}/>
@@ -72,7 +72,7 @@ function SampleDetails(props) {
                         </span>
                     </td>
                 </tr>
-                <tr>
+                <tr className="copyable">
                     <th>sha512</th>
                     <td id="sha512">
                         <Hash hash={props.sha512}/>
@@ -81,7 +81,7 @@ function SampleDetails(props) {
                         </span>
                     </td>
                 </tr>
-                <tr>
+                <tr className="copyable">
                     <th>crc32</th>
                     <td id="crc32" className="text-monospace">
                         {props.crc32}
@@ -90,7 +90,7 @@ function SampleDetails(props) {
                         </span>
                     </td>
                 </tr>
-                <tr>
+                <tr className="copyable">
                     <th>ssdeep</th>
                     <td id="ssdeep" className="text-monospace">
                         <Link to={makeSearchLink("ssdeep", props.ssdeep, false, '')}>{props.ssdeep}</Link>

--- a/malwarecage/web/src/styles/index.css
+++ b/malwarecage/web/src/styles/index.css
@@ -247,18 +247,18 @@ a.blob {
     z-index: 3;
 }
 
-.flicker-element td i {
+.copyable i {
     visibility: hidden;
 }
 
-.flicker-element td:hover i {
+.copyable:hover i {
     visibility: visible;
 }
 
-.flicker-element td i:hover {
+.copyable i:hover {
     color: var(--blue);
 }
 
-.flicker-element td i:active {
+.copyable i:active {
     color: var(--red);
 }

--- a/malwarecage/web/src/styles/index.css
+++ b/malwarecage/web/src/styles/index.css
@@ -247,18 +247,18 @@ a.blob {
     z-index: 3;
 }
 
-.copyable i {
+.flickerable i {
     visibility: hidden;
 }
 
-.copyable:hover i {
+.flickerable:hover i {
     visibility: visible;
 }
 
-.copyable i:hover {
+.flickerable i:hover {
     color: var(--blue);
 }
 
-.copyable i:active {
+.flickerable i:active {
     color: var(--red);
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
- Showing "copy to clipboard" button on hover doesn't work correctly for nested dicts in lists
![image](https://user-images.githubusercontent.com/8720367/92015589-51e02780-ed51-11ea-8fd1-089d4188297c.png)
- Only `<td>` elements are hoverable in current CSS, all elements should be allowed

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
- Fixed "dict in list" issue
![image](https://user-images.githubusercontent.com/8720367/92015706-7cca7b80-ed51-11ea-8efb-95bbf54dec2d.png)
- Now, we're marking the element with `copyable` class where hover event should show the button, instead of marking the container making all td's hoverable.
