### PR TITLE
Fix: Added noEllipsis attribute to Recent view for rows that shouldn't be cropped

### DIFF
--- a/malwarecage/web/src/components/RecentBlobs.js
+++ b/malwarecage/web/src/components/RecentBlobs.js
@@ -40,10 +40,10 @@ export function RecentBlobRow(props) {
                 <RecentInnerRow labelWidth="3rem" label="Type" value={props.blob_type} narrowOnly copyable>
                     {blobType}
                 </RecentInnerRow>
-                <RecentInnerRow labelWidth="3rem" label="Date" value={props.upload_time} narrowOnly>
+                <RecentInnerRow labelWidth="3rem" label="Date" value={props.upload_time} narrowOnly noEllipsis>
                     {firstSeen}
                 </RecentInnerRow>
-                <RecentInnerRow narrowOnly>
+                <RecentInnerRow narrowOnly noEllipsis>
                     {tags}
                 </RecentInnerRow>
                 {/* Wide mode */}
@@ -59,19 +59,19 @@ export function RecentBlobRow(props) {
             </td>
             <td className="col-lg-2 d-none d-lg-block">
                 {/* Wide mode */}
-                <RecentInnerRow>
+                <RecentInnerRow noEllipsis>
                     {tags}
                 </RecentInnerRow>
             </td>
             <td className="col-lg-2 d-none d-lg-block">
                 {/* Wide mode */}
-                <RecentInnerRow value={props.upload_time}>
+                <RecentInnerRow value={props.upload_time} noEllipsis>
                     {firstSeen}
                 </RecentInnerRow>
             </td>
             <td className="col-lg-2 d-none d-lg-block">
                 {/* Wide mode */}
-                <RecentInnerRow value={props.last_seen}>
+                <RecentInnerRow value={props.last_seen} noEllipsis>
                     {lastSeen}
                 </RecentInnerRow>
             </td>

--- a/malwarecage/web/src/components/RecentConfigs.js
+++ b/malwarecage/web/src/components/RecentConfigs.js
@@ -51,10 +51,10 @@ export function RecentConfigRow(props) {
                 <RecentInnerRow labelWidth="3rem" label="Type" value={props.config_type} narrowOnly copyable>
                     {configType}
                 </RecentInnerRow>
-                <RecentInnerRow labelWidth="3rem" label="Date" value={props.upload_time} narrowOnly>
+                <RecentInnerRow labelWidth="3rem" label="Date" value={props.upload_time} narrowOnly noEllipsis>
                     {uploadTime}
                 </RecentInnerRow>
-                <RecentInnerRow narrowOnly>
+                <RecentInnerRow narrowOnly noEllipsis>
                     {tags}
                 </RecentInnerRow>
                 {/* Wide mode */}
@@ -68,12 +68,12 @@ export function RecentConfigRow(props) {
                 </RecentInnerRow>
             </td>
             <td className="col-lg-4 d-none d-lg-block">
-                <RecentInnerRow>
+                <RecentInnerRow noEllipsis>
                     {tags}
                 </RecentInnerRow>
             </td>
             <td className="col-lg-2 d-none d-lg-block">
-                <RecentInnerRow value={props.upload_time}>
+                <RecentInnerRow value={props.upload_time} noEllipsis>
                     {uploadTime}
                 </RecentInnerRow>
             </td>

--- a/malwarecage/web/src/components/RecentSamples.js
+++ b/malwarecage/web/src/components/RecentSamples.js
@@ -36,7 +36,7 @@ export function RecentFileRow(props) {
                 <RecentInnerRow value={props.sha256} narrowOnly copyable>
                     <ObjectLink type="file" id={props.sha256}/>
                 </RecentInnerRow>
-                <RecentInnerRow value={props.upload_time} narrowOnly>
+                <RecentInnerRow value={props.upload_time} narrowOnly noEllipsis>
                     {uploadTime}
                 </RecentInnerRow>
             </td>
@@ -45,19 +45,19 @@ export function RecentFileRow(props) {
                 <RecentInnerRow labelWidth="3rem" label="Size" value={props.file_size} copyable />
                 <RecentInnerRow labelWidth="3rem" label="Type" value={props.file_type} copyable />
                 {/* Shrink mode */}
-                <RecentInnerRow narrowOnly>
+                <RecentInnerRow narrowOnly noEllipsis>
                     {tags}
                 </RecentInnerRow>
             </td>
             <td className="col-lg-3 d-none d-lg-block">
                 {/* Wide mode */}
-                <RecentInnerRow>
+                <RecentInnerRow noEllipsis>
                     {tags}
                 </RecentInnerRow>
             </td>
             <td className="col-lg-2 d-none d-lg-block">
                 {/* Wide mode */}
-                <RecentInnerRow value={props.upload_time}>
+                <RecentInnerRow value={props.upload_time} noEllipsis>
                     {uploadTime}
                 </RecentInnerRow>
             </td>

--- a/malwarecage/web/src/components/RecentView/RecentInnerRow.js
+++ b/malwarecage/web/src/components/RecentView/RecentInnerRow.js
@@ -16,7 +16,7 @@ export default function RecentInnerRow(props) {
                     <b style={{minWidth: props.labelWidth}}>{props.label}: </b>
                 ) : []
             }
-            <div className="recent-field" data-toggle="tooltip" title={props.value}>
+            <div className={!props.noEllipsis ? "recent-field" : ""} data-toggle="tooltip" title={props.value}>
                 {props.children || props.value}
             </div>
             {


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](CONTRIBUTING.md).
- [x] I've tested my changes by building and running the project, and testing changed functionality (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

- Currently if there are too many tags, some of them are hidden behind ellipsis

![image](https://user-images.githubusercontent.com/8720367/92157145-4d3b7200-ee2a-11ea-88cc-c41079924c6e.png)

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

![image](https://user-images.githubusercontent.com/8720367/92157310-8d025980-ee2a-11ea-9d2d-908afbfb2cac.png)
